### PR TITLE
Adds gain scoring metrics

### DIFF
--- a/doc/whats_new/v1.2.rst
+++ b/doc/whats_new/v1.2.rst
@@ -205,6 +205,17 @@ Changelog
 :mod:`sklearn.metrics`
 ......................
 
+- |Feature| Adds new functions:
+  :func:`metrics.f1_gain_score`,
+  :func:`metrics.fbeta_gain_score`,
+  :func:`metrics.precision_recall_fgain_score_support`,
+  :func:`metrics.precision_gain_score`,
+  :func:`metrics.recall_gain_score`
+  The functions compute the gain variants of the traditional precision, recall
+  and f-score metrics as described in
+  :ref:`https://papers.nips.cc/paper/2015/file/33e8075e9970de0cfea955afd4644bb2-Paper.pdf`.
+  :pr:`24121` by :user:`Bradley Fowler <bradleyfowler123>`.
+
 - |Feature| :func:`metrics.class_likelihood_ratios` is added to compute the positive and
   negative likelihood ratios derived from the confusion matrix
   of a binary classification problem. :pr:`22518` by

--- a/sklearn/metrics/__init__.py
+++ b/sklearn/metrics/__init__.py
@@ -23,16 +23,21 @@ from ._classification import class_likelihood_ratios
 from ._classification import classification_report
 from ._classification import cohen_kappa_score
 from ._classification import confusion_matrix
+from ._classification import f1_gain_score
 from ._classification import f1_score
 from ._classification import fbeta_score
+from ._classification import fbeta_gain_score
 from ._classification import hamming_loss
 from ._classification import hinge_loss
 from ._classification import jaccard_score
 from ._classification import log_loss
 from ._classification import matthews_corrcoef
 from ._classification import precision_recall_fscore_support
+from ._classification import precision_recall_fgain_score_support
 from ._classification import precision_score
+from ._classification import precision_gain_score
 from ._classification import recall_score
+from ._classification import recall_gain_score
 from ._classification import zero_one_loss
 from ._classification import brier_score_loss
 from ._classification import multilabel_confusion_matrix
@@ -129,7 +134,9 @@ __all__ = [
     "euclidean_distances",
     "explained_variance_score",
     "f1_score",
+    "f1_gain_score",
     "fbeta_score",
+    "fbeta_gain_score",
     "fowlkes_mallows_score",
     "get_scorer",
     "hamming_loss",
@@ -170,10 +177,13 @@ __all__ = [
     "PrecisionRecallDisplay",
     "precision_recall_curve",
     "precision_recall_fscore_support",
+    "precision_recall_fgain_score_support",
     "precision_score",
+    "precision_gain_score",
     "r2_score",
     "rand_score",
     "recall_score",
+    "recall_gain_score",
     "RocCurveDisplay",
     "roc_auc_score",
     "roc_curve",

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -3162,7 +3162,7 @@ def f1_gain_score(
         setting ``labels=[pos_label]`` and ``average != 'binary'`` will report
         scores for that label only.
 
-    average : {'micro', 'macro', 'samples', 'weighted', 'binary'} or None, \
+    average : {'macro', 'weighted', 'binary'} or None, \
             default='binary'
         This parameter is required for multiclass/multilabel targets.
         If ``None``, the scores for each class are returned. Otherwise, this
@@ -3171,9 +3171,6 @@ def f1_gain_score(
         ``'binary'``:
             Only report results for the class specified by ``pos_label``.
             This is applicable only if targets (``y_{true,pred}``) are binary.
-        ``'micro'``:
-            Calculate metrics globally by counting the total true positives,
-            false negatives and false positives.
         ``'macro'``:
             Calculate metrics for each label, and find their unweighted
             mean.  This does not take label imbalance into account.
@@ -3182,10 +3179,6 @@ def f1_gain_score(
             by support (the number of true instances for each label). This
             alters 'macro' to account for label imbalance; it can result in an
             F-score that is not between precision and recall.
-        ``'samples'``:
-            Calculate metrics for each instance, and find their average (only
-            meaningful for multilabel classification where this differs from
-            :func:`accuracy_score`).
 
     sample_weight : array-like of shape (n_samples,), default=None
         Sample weights.
@@ -3232,26 +3225,24 @@ def f1_gain_score(
 
     Examples
     --------
-    >>> from sklearn.metrics import f1_score
-    >>> y_true = [0, 1, 2, 0, 1, 2]
-    >>> y_pred = [0, 2, 1, 0, 0, 1]
-    >>> f1_score(y_true, y_pred, average='macro')
-    0.26...
-    >>> f1_score(y_true, y_pred, average='micro')
-    0.33...
-    >>> f1_score(y_true, y_pred, average='weighted')
-    0.26...
-    >>> f1_score(y_true, y_pred, average=None)
-    array([0.8, 0. , 0. ])
+    >>> from sklearn.metrics import f1_gain_score
+    >>> y_true = [0, 1, 2, 0, 1, 2, 2]
+    >>> y_pred = [0, 2, 1, 0, 1, 1, 2]
+    >>> f1_gain_score(y_true, y_pred, average='macro')
+    0.42...
+    >>> f1_gain_score(y_true, y_pred, average='weighted')
+    0.34...
+    >>> f1_gain_score(y_true, y_pred, average=None)
+    array([1.0, 0.4 , -0.125])
     >>> y_true = [0, 0, 0, 0, 0, 0]
     >>> y_pred = [0, 0, 0, 0, 0, 0]
-    >>> f1_score(y_true, y_pred, zero_division=1)
-    1.0...
+    >>> f1_gain_score(y_true, y_pred, zero_division=1)
+    1.0
     >>> # multilabel classification
     >>> y_true = [[0, 0, 0], [1, 1, 1], [0, 1, 1]]
     >>> y_pred = [[0, 0, 0], [1, 1, 1], [1, 1, 0]]
-    >>> f1_score(y_true, y_pred, average=None)
-    array([0.66666667, 1.        , 0.66666667])
+    >>> f1_gain_score(y_true, y_pred, average=None)
+    array([0.75, 1. , 0.])
     """
     return fbeta_gain_score(
         y_true,
@@ -3320,7 +3311,7 @@ def fbeta_gain_score(
         setting ``labels=[pos_label]`` and ``average != 'binary'`` will report
         scores for that label only.
 
-    average : {'micro', 'macro', 'samples', 'weighted', 'binary'} or None, \
+    average : {'macro', 'weighted', 'binary'} or None, \
             default='binary'
         This parameter is required for multiclass/multilabel targets.
         If ``None``, the scores for each class are returned. Otherwise, this
@@ -3329,9 +3320,6 @@ def fbeta_gain_score(
         ``'binary'``:
             Only report results for the class specified by ``pos_label``.
             This is applicable only if targets (``y_{true,pred}``) are binary.
-        ``'micro'``:
-            Calculate metrics globally by counting the total true positives,
-            false negatives and false positives.
         ``'macro'``:
             Calculate metrics for each label, and find their unweighted
             mean.  This does not take label imbalance into account.
@@ -3340,10 +3328,6 @@ def fbeta_gain_score(
             by support (the number of true instances for each label). This
             alters 'macro' to account for label imbalance; it can result in an
             F-score that is not between precision and recall.
-        ``'samples'``:
-            Calculate metrics for each instance, and find their average (only
-            meaningful for multilabel classification where this differs from
-            :func:`accuracy_score`).
 
     sample_weight : array-like of shape (n_samples,), default=None
         Sample weights.
@@ -3391,17 +3375,15 @@ def fbeta_gain_score(
 
     Examples
     --------
-    >>> from sklearn.metrics import fbeta_score
-    >>> y_true = [0, 1, 2, 0, 1, 2]
-    >>> y_pred = [0, 2, 1, 0, 0, 1]
-    >>> fbeta_score(y_true, y_pred, average='macro', beta=0.5)
-    0.23...
-    >>> fbeta_score(y_true, y_pred, average='micro', beta=0.5)
-    0.33...
-    >>> fbeta_score(y_true, y_pred, average='weighted', beta=0.5)
-    0.23...
-    >>> fbeta_score(y_true, y_pred, average=None, beta=0.5)
-    array([0.71..., 0.        , 0.        ])
+    >>> from sklearn.metrics import fbeta_gain_score
+    >>> y_true = [0, 1, 2, 0, 1, 2, 2]
+    >>> y_pred = [0, 2, 1, 0, 1, 1, 2]
+    >>> fbeta_gain_score(y_true, y_pred, average='macro', beta=0.5)
+    0.45...
+    >>> fbeta_gain_score(y_true, y_pred, average='weighted', beta=0.5)
+    0.40...
+    >>> fbeta_gain_score(y_true, y_pred, average=None, beta=0.5)
+    array([1., 0.28 , 0.1])
     """
 
     _, _, f, _ = precision_recall_fgain_score_support(
@@ -3496,7 +3478,7 @@ def precision_recall_fgain_score_support(
         setting ``labels=[pos_label]`` and ``average != 'binary'`` will report
         scores for that label only.
 
-    average : {'binary', 'micro', 'macro', 'samples', 'weighted'}, \
+    average : {'binary', 'macro', 'weighted'}, \
             default=None
         If ``None``, the scores for each class are returned. Otherwise, this
         determines the type of averaging performed on the data:
@@ -3504,9 +3486,6 @@ def precision_recall_fgain_score_support(
         ``'binary'``:
             Only report results for the class specified by ``pos_label``.
             This is applicable only if targets (``y_{true,pred}``) are binary.
-        ``'micro'``:
-            Calculate metrics globally by counting the total true positives,
-            false negatives and false positives.
         ``'macro'``:
             Calculate metrics for each label, and find their unweighted
             mean.  This does not take label imbalance into account.
@@ -3515,10 +3494,6 @@ def precision_recall_fgain_score_support(
             by support (the number of true instances for each label). This
             alters 'macro' to account for label imbalance; it can result in an
             F-score that is not between precision and recall.
-        ``'samples'``:
-            Calculate metrics for each instance, and find their average (only
-            meaningful for multilabel classification where this differs from
-            :func:`accuracy_score`).
 
     warn_for : tuple or set, for internal use
         This determines which warnings will be made in the case that this
@@ -3584,26 +3559,27 @@ def precision_recall_fgain_score_support(
     Examples
     --------
     >>> import numpy as np
-    >>> from sklearn.metrics import precision_recall_fscore_support
-    >>> y_true = np.array(['cat', 'dog', 'pig', 'cat', 'dog', 'pig'])
-    >>> y_pred = np.array(['cat', 'pig', 'dog', 'cat', 'cat', 'dog'])
-    >>> precision_recall_fscore_support(y_true, y_pred, average='macro')
-    (0.22..., 0.33..., 0.26..., None)
-    >>> precision_recall_fscore_support(y_true, y_pred, average='micro')
-    (0.33..., 0.33..., 0.33..., None)
-    >>> precision_recall_fscore_support(y_true, y_pred, average='weighted')
-    (0.22..., 0.33..., 0.26..., None)
+    >>> from sklearn.metrics import precision_recall_fgain_score_support
+    >>> y_true = np.array(['cat', 'dog', 'pig', 'dog', 'cat', 'pig', 'pig'])
+    >>> y_pred = np.array(['cat', 'pig', 'dog', 'dog', 'cat', 'dog', 'pig'])
+    >>> precision_recall_fgain_score_support(y_true, y_pred, average='macro')
+    (0.48..., 0.36..., 0.42..., None)
+    >>> precision_recall_fgain_score_support(y_true, y_pred, average='weighted')
+    (0.45..., 0.24..., 0.34..., None)
 
     It is possible to compute per-label precisions, recalls, F1-scores and
     supports instead of averaging:
 
-    >>> precision_recall_fscore_support(y_true, y_pred, average=None,
+    >>> precision_recall_fgain_score_support(y_true, y_pred, average=None,
     ... labels=['pig', 'dog', 'cat'])
-    (array([0.        , 0.        , 0.66...]),
-     array([0., 0., 1.]), array([0. , 0. , 0.8]),
-     array([2, 2, 2]))
+    (
+        array([0.25, 0.2, 1.]),
+        array([-0.5., 0.6, 1.]),
+        array([-0.125. , 0.4 , 1.]),
+        array([3, 2, 2])
+    )
     """
-    average_options = (None, "binary", "macro", "weighted", "samples")
+    average_options = (None, "binary", "macro", "weighted")
     if average not in average_options:
         raise ValueError("average has to be one of " + str(average_options))
 
@@ -3676,7 +3652,7 @@ def precision_gain_score(
         setting ``labels=[pos_label]`` and ``average != 'binary'`` will report
         scores for that label only.
 
-    average : {'micro', 'macro', 'samples', 'weighted', 'binary'} or None, \
+    average : {'macro', 'weighted', 'binary'} or None, \
             default='binary'
         This parameter is required for multiclass/multilabel targets.
         If ``None``, the scores for each class are returned. Otherwise, this
@@ -3685,9 +3661,6 @@ def precision_gain_score(
         ``'binary'``:
             Only report results for the class specified by ``pos_label``.
             This is applicable only if targets (``y_{true,pred}``) are binary.
-        ``'micro'``:
-            Calculate metrics globally by counting the total true positives,
-            false negatives and false positives.
         ``'macro'``:
             Calculate metrics for each label, and find their unweighted
             mean.  This does not take label imbalance into account.
@@ -3696,10 +3669,6 @@ def precision_gain_score(
             by support (the number of true instances for each label). This
             alters 'macro' to account for label imbalance; it can result in an
             F-score that is not between precision and recall.
-        ``'samples'``:
-            Calculate metrics for each instance, and find their average (only
-            meaningful for multilabel classification where this differs from
-            :func:`accuracy_score`).
 
     sample_weight : array-like of shape (n_samples,), default=None
         Sample weights.
@@ -3751,8 +3720,6 @@ def precision_gain_score(
     >>> y_pred = [0, 2, 1, 0, 0, 1]
     >>> precision_score(y_true, y_pred, average='macro')
     0.22...
-    >>> precision_score(y_true, y_pred, average='micro')
-    0.33...
     >>> precision_score(y_true, y_pred, average='weighted')
     0.22...
     >>> precision_score(y_true, y_pred, average=None)
@@ -3835,7 +3802,7 @@ def recall_gain_score(
         setting ``labels=[pos_label]`` and ``average != 'binary'`` will report
         scores for that label only.
 
-    average : {'micro', 'macro', 'samples', 'weighted', 'binary'} or None, \
+    average : {'macro', 'weighted', 'binary'} or None, \
             default='binary'
         This parameter is required for multiclass/multilabel targets.
         If ``None``, the scores for each class are returned. Otherwise, this
@@ -3844,9 +3811,6 @@ def recall_gain_score(
         ``'binary'``:
             Only report results for the class specified by ``pos_label``.
             This is applicable only if targets (``y_{true,pred}``) are binary.
-        ``'micro'``:
-            Calculate metrics globally by counting the total true positives,
-            false negatives and false positives.
         ``'macro'``:
             Calculate metrics for each label, and find their unweighted
             mean.  This does not take label imbalance into account.
@@ -3856,10 +3820,6 @@ def recall_gain_score(
             alters 'macro' to account for label imbalance; it can result in an
             F-score that is not between precision and recall. Weighted recall
             is equal to accuracy.
-        ``'samples'``:
-            Calculate metrics for each instance, and find their average (only
-            meaningful for multilabel classification where this differs from
-            :func:`accuracy_score`).
 
     sample_weight : array-like of shape (n_samples,), default=None
         Sample weights.
@@ -3912,8 +3872,6 @@ def recall_gain_score(
     >>> y_true = [0, 1, 2, 0, 1, 2]
     >>> y_pred = [0, 2, 1, 0, 0, 1]
     >>> recall_score(y_true, y_pred, average='macro')
-    0.33...
-    >>> recall_score(y_true, y_pred, average='micro')
     0.33...
     >>> recall_score(y_true, y_pred, average='weighted')
     0.33...

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -1583,7 +1583,7 @@ def _precision_recall_fscore_support(
     sample_weight=None,
     zero_division="warn",
     return_in_gain_space=False,
-    proportion_positives=None,
+    class_distribution=None,
 ):
     """Compute precision, recall, F-measure and support for each class.
 
@@ -1677,7 +1677,7 @@ def _precision_recall_fscore_support(
         If set to "warn", this acts as 0, but warnings are also raised.
 
     return_in_gain_space : TODO
-    proportion_positives=None : TODO
+    class_distribution=None : TODO
 
     Returns
     -------
@@ -1744,6 +1744,7 @@ def _precision_recall_fscore_support(
     if beta < 0:
         raise ValueError("beta should be >=0 in the F-beta score")
     labels = _check_set_wise_labels(y_true, y_pred, average, labels, pos_label)
+    _check_valid_class_distribution(class_distribution, y_true)
 
     # Calculate tp_sum, pred_sum, true_sum ###
     samplewise = average == "samples"
@@ -1801,8 +1802,8 @@ def _precision_recall_fscore_support(
         ) in enumerate(zip(precision, recall, f_score, true_sum, MCM)):
             pi = (
                 (true_sum_i / cm_i.sum())
-                if proportion_positives is None
-                else proportion_positives[class_index]
+                if class_distribution is None
+                else class_distribution[class_index]
             )
             precision[class_index] = prg_gain_transform(precision_i, pi=pi)
             recall[class_index] = prg_gain_transform(recall_i, pi=pi)
@@ -3081,6 +3082,18 @@ def brier_score_loss(y_true, y_prob, *, sample_weight=None, pos_label=None):
     return np.average((y_true - y_prob) ** 2, weights=sample_weight)
 
 
+def _check_valid_class_distribution(class_distribution, y_true):
+    if class_distribution:
+        num_classes = len(set(y_true))
+        if len(class_distribution) != num_classes:
+            raise ValueError(
+                "Class distribution must have the same length as the number of classes"
+                f" - {num_classes}."
+            )
+        if sum(class_distribution) != 1:
+            raise ValueError("Class distribution values do not sum to 1.")
+
+
 def f1_gain_score(
     y_true,
     y_pred,
@@ -3375,7 +3388,7 @@ def precision_recall_fgain_score_support(
     y_true,
     y_pred,
     *,
-    proportion_positives=None,
+    class_distribution=None,
     beta=1.0,
     labels=None,
     pos_label=1,
@@ -3400,7 +3413,7 @@ def precision_recall_fgain_score_support(
         sample_weight=sample_weight,
         zero_division=zero_division,
         return_in_gain_space=True,
-        proportion_positives=proportion_positives,
+        class_distribution=class_distribution,
     )
 
 

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -1676,8 +1676,13 @@ def _precision_recall_fscore_support(
 
         If set to "warn", this acts as 0, but warnings are also raised.
 
-    return_in_gain_space : TODO
-    class_distribution=None : TODO
+    return_in_gain_space : bool, default=False
+        If True, Precision Gain, Recall Gain and FScore Gain are returned.
+
+    class_distribution : Optional list, default=None
+        The proportion that each class makes up in the dataset. It's used only
+        when return_in_gain_space=True. If not provided then it's estimated from
+        y_true.
 
     Returns
     -------
@@ -1802,14 +1807,16 @@ def _precision_recall_fscore_support(
             true_sum_i,
             cm_i,
         ) in enumerate(zip(precision, recall, f_score, true_sum, MCM)):
-            pi = (
+            class_proportion = (
                 (true_sum_i / cm_i.sum())
                 if class_distribution is None
                 else class_distribution[class_index]
             )
-            precision[class_index] = prg_gain_transform(precision_i, pi=pi)
-            recall[class_index] = prg_gain_transform(recall_i, pi=pi)
-            f_score[class_index] = prg_gain_transform(f_score_i, pi=pi)
+            precision[class_index] = prg_gain_transform(
+                precision_i, pi=class_proportion
+            )
+            recall[class_index] = prg_gain_transform(recall_i, pi=class_proportion)
+            f_score[class_index] = prg_gain_transform(f_score_i, pi=class_proportion)
 
     # Average the results
     if average == "weighted":
@@ -3407,7 +3414,162 @@ def precision_recall_fgain_score_support(
     sample_weight=None,
     zero_division="warn",
 ):
-    """TODO"""
+    """Compute precision, recall, F-measure and support for each class.
+
+    The precision is the ratio ``tp / (tp + fp)`` where ``tp`` is the number of
+    true positives and ``fp`` the number of false positives. The precision is
+    intuitively the ability of the classifier not to label a negative sample as
+    positive.
+
+    The recall is the ratio ``tp / (tp + fn)`` where ``tp`` is the number of
+    true positives and ``fn`` the number of false negatives. The recall is
+    intuitively the ability of the classifier to find all the positive samples.
+
+    The F-beta score can be interpreted as a weighted harmonic mean of
+    the precision and recall, where an F-beta score reaches its best
+    value at 1 and worst score at 0.
+
+    The F-beta score weights recall more than precision by a factor of
+    ``beta``. ``beta == 1.0`` means recall and precision are equally important.
+
+    The support is the number of occurrences of each class in ``y_true``.
+
+    If ``pos_label is None`` and in binary classification, this function
+    returns the average precision, recall and F-measure if ``average``
+    is one of ``'micro'``, ``'macro'``, ``'weighted'`` or ``'samples'``.
+
+    Read more in the :ref:`User Guide <precision_recall_f_measure_metrics>`.
+
+    Parameters
+    ----------
+    y_true : 1d array-like, or label indicator array / sparse matrix
+        Ground truth (correct) target values.
+
+    y_pred : 1d array-like, or label indicator array / sparse matrix
+        Estimated targets as returned by a classifier.
+
+    beta : float, default=1.0
+        The strength of recall versus precision in the F-score.
+
+    labels : array-like, default=None
+        The set of labels to include when ``average != 'binary'``, and their
+        order if ``average is None``. Labels present in the data can be
+        excluded, for example to calculate a multiclass average ignoring a
+        majority negative class, while labels not present in the data will
+        result in 0 components in a macro average. For multilabel targets,
+        labels are column indices. By default, all labels in ``y_true`` and
+        ``y_pred`` are used in sorted order.
+
+    pos_label : str or int, default=1
+        The class to report if ``average='binary'`` and the data is binary.
+        If the data are multiclass or multilabel, this will be ignored;
+        setting ``labels=[pos_label]`` and ``average != 'binary'`` will report
+        scores for that label only.
+
+    average : {'binary', 'micro', 'macro', 'samples', 'weighted'}, \
+            default=None
+        If ``None``, the scores for each class are returned. Otherwise, this
+        determines the type of averaging performed on the data:
+
+        ``'binary'``:
+            Only report results for the class specified by ``pos_label``.
+            This is applicable only if targets (``y_{true,pred}``) are binary.
+        ``'micro'``:
+            Calculate metrics globally by counting the total true positives,
+            false negatives and false positives.
+        ``'macro'``:
+            Calculate metrics for each label, and find their unweighted
+            mean.  This does not take label imbalance into account.
+        ``'weighted'``:
+            Calculate metrics for each label, and find their average weighted
+            by support (the number of true instances for each label). This
+            alters 'macro' to account for label imbalance; it can result in an
+            F-score that is not between precision and recall.
+        ``'samples'``:
+            Calculate metrics for each instance, and find their average (only
+            meaningful for multilabel classification where this differs from
+            :func:`accuracy_score`).
+
+    warn_for : tuple or set, for internal use
+        This determines which warnings will be made in the case that this
+        function is being used to return only one of its metrics.
+
+    sample_weight : array-like of shape (n_samples,), default=None
+        Sample weights.
+
+    zero_division : "warn", 0 or 1, default="warn"
+        Sets the value to return when there is a zero division:
+           - recall: when there are no positive labels
+           - precision: when there are no positive predictions
+           - f-score: both
+
+        If set to "warn", this acts as 0, but warnings are also raised.
+
+    class_distribution : Optional list, default=None
+        The proportion that each class makes up in the dataset. If not
+        provided then it's estimated from y_true.
+
+    Returns
+    -------
+    precision : float (if average is not None) or array of float, shape =\
+        [n_unique_labels]
+        Precision score.
+
+    recall : float (if average is not None) or array of float, shape =\
+        [n_unique_labels]
+        Recall score.
+
+    fbeta_score : float (if average is not None) or array of float, shape =\
+        [n_unique_labels]
+        F-beta score.
+
+    support : None (if average is not None) or array of int, shape =\
+        [n_unique_labels]
+        The number of occurrences of each label in ``y_true``.
+
+    Notes
+    -----
+    When ``true positive + false positive == 0``, precision is undefined.
+    When ``true positive + false negative == 0``, recall is undefined.
+    In such cases, by default the metric will be set to 0, as will f-score,
+    and ``UndefinedMetricWarning`` will be raised. This behavior can be
+    modified with ``zero_division``.
+
+    References
+    ----------
+    .. [1] `Wikipedia entry for the Precision and recall
+           <https://en.wikipedia.org/wiki/Precision_and_recall>`_.
+
+    .. [2] `Wikipedia entry for the F1-score
+           <https://en.wikipedia.org/wiki/F1_score>`_.
+
+    .. [3] `Discriminative Methods for Multi-labeled Classification Advances
+           in Knowledge Discovery and Data Mining (2004), pp. 22-30 by Shantanu
+           Godbole, Sunita Sarawagi
+           <http://www.godbole.net/shantanu/pubs/multilabelsvm-pakdd04.pdf>`_.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> from sklearn.metrics import precision_recall_fscore_support
+    >>> y_true = np.array(['cat', 'dog', 'pig', 'cat', 'dog', 'pig'])
+    >>> y_pred = np.array(['cat', 'pig', 'dog', 'cat', 'cat', 'dog'])
+    >>> precision_recall_fscore_support(y_true, y_pred, average='macro')
+    (0.22..., 0.33..., 0.26..., None)
+    >>> precision_recall_fscore_support(y_true, y_pred, average='micro')
+    (0.33..., 0.33..., 0.33..., None)
+    >>> precision_recall_fscore_support(y_true, y_pred, average='weighted')
+    (0.22..., 0.33..., 0.26..., None)
+
+    It is possible to compute per-label precisions, recalls, F1-scores and
+    supports instead of averaging:
+
+    >>> precision_recall_fscore_support(y_true, y_pred, average=None,
+    ... labels=['pig', 'dog', 'cat'])
+    (array([0.        , 0.        , 0.66...]),
+     array([0., 0., 1.]), array([0. , 0. , 0.8]),
+     array([2, 2, 2]))
+    """
     average_options = (None, "binary", "macro", "weighted", "samples")
     if average not in average_options:
         raise ValueError("average has to be one of " + str(average_options))

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -3120,6 +3120,7 @@ def f1_gain_score(
     average="binary",
     sample_weight=None,
     zero_division="warn",
+    class_distribution=None,
 ):
     """Compute the F1 score, also known as balanced F-score or F-measure.
 
@@ -3195,6 +3196,10 @@ def f1_gain_score(
         predictions and labels are negative. If set to "warn", this acts as 0,
         but warnings are also raised.
 
+    class_distribution : Optional list, default=None
+        The proportion that each class makes up in the dataset. If not
+        provided then it's estimated from y_true.
+
     Returns
     -------
     f1_score : float or array of float, shape = [n_unique_labels]
@@ -3255,6 +3260,7 @@ def f1_gain_score(
         average=average,
         sample_weight=sample_weight,
         zero_division=zero_division,
+        class_distribution=class_distribution,
     )
 
 
@@ -3268,6 +3274,7 @@ def fbeta_gain_score(
     average="binary",
     sample_weight=None,
     zero_division="warn",
+    class_distribution=None,
 ):
     """Compute the F-beta score.
 
@@ -3343,6 +3350,10 @@ def fbeta_gain_score(
         predictions and labels are negative. If set to "warn", this acts as 0,
         but warnings are also raised.
 
+    class_distribution : Optional list, default=None
+        The proportion that each class makes up in the dataset. If not
+        provided then it's estimated from y_true.
+
     Returns
     -------
     fbeta_score : float (if average is not None) or array of float, shape =\
@@ -3397,6 +3408,7 @@ def fbeta_gain_score(
         warn_for=("f-score",),
         sample_weight=sample_weight,
         zero_division=zero_division,
+        class_distribution=class_distribution,
     )
     return f
 
@@ -3598,6 +3610,7 @@ def precision_gain_score(
     average="binary",
     sample_weight=None,
     zero_division="warn",
+    class_distribution=None,
 ):
     """Compute the precision.
 
@@ -3668,6 +3681,10 @@ def precision_gain_score(
         Sets the value to return when there is a zero division. If set to
         "warn", this acts as 0, but warnings are also raised.
 
+    class_distribution : Optional list, default=None
+        The proportion that each class makes up in the dataset. If not
+        provided then it's estimated from y_true.
+
     Returns
     -------
     precision : float (if average is not None) or array of float of shape \
@@ -3727,6 +3744,7 @@ def precision_gain_score(
         warn_for=("precision",),
         sample_weight=sample_weight,
         zero_division=zero_division,
+        class_distribution=class_distribution,
     )
     return p
 
@@ -3740,6 +3758,7 @@ def recall_gain_score(
     average="binary",
     sample_weight=None,
     zero_division="warn",
+    class_distribution=None,
 ):
     """Compute the recall.
 
@@ -3810,6 +3829,10 @@ def recall_gain_score(
         Sets the value to return when there is a zero division. If set to
         "warn", this acts as 0, but warnings are also raised.
 
+    class_distribution : Optional list, default=None
+        The proportion that each class makes up in the dataset. If not
+        provided then it's estimated from y_true.
+
     Returns
     -------
     recall : float (if average is not None) or array of float of shape \
@@ -3871,10 +3894,11 @@ def recall_gain_score(
         warn_for=("recall",),
         sample_weight=sample_weight,
         zero_division=zero_division,
+        class_distribution=class_distribution,
     )
     return r
 
 
 def prg_gain_transform(x, *, pi):
-    """pi = proportion positives"""
+    """Transfrom from PG space into PRG space. pi = proportion positives"""
     return (x - pi) / ((1 - pi) * x)

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -3122,19 +3122,18 @@ def f1_gain_score(
     zero_division="warn",
     class_distribution=None,
 ):
-    """Compute the F1 score, also known as balanced F-score or F-measure.
+    """Compute the F1 Gain score, also known as balanced F-Gain score or
+    F-Gain measure.
 
-    The F1 score can be interpreted as a harmonic mean of the precision and
-    recall, where an F1 score reaches its best value at 1 and worst score at 0.
-    The relative contribution of precision and recall to the F1 score are
-    equal. The formula for the F1 score is::
+    The F1 Gain score can be interpreted as a arithmetic mean of the precision
+    gain and recall gain, where an F1 Gain score reaches its best value at 1 and
+    worst score at -Inf. The relative contribution of precision and recall to
+    the F1 score are equal. The formula for the F1 score is::
 
-        F1 = 2 * (precision * recall) / (precision + recall)
+        F1_Gain = (precision_gain + recall_gain) / 2
 
-    In the multi-class and multi-label case, this is the average of
-    the F1 score of each class with weighting depending on the ``average``
-    parameter.
-
+    In the multi-class and multi-label case, this is the average of the F1 Gain
+    score of each class with weighting depending on the ``average`` parameter.
     Read more in the :ref:`User Guide <precision_recall_f_measure_metrics>`.
 
     Parameters
@@ -3202,15 +3201,15 @@ def f1_gain_score(
 
     Returns
     -------
-    f1_score : float or array of float, shape = [n_unique_labels]
-        F1 score of the positive class in binary classification or weighted
-        average of the F1 scores of each class for the multiclass task.
+    f1_gain_score : float or array of float, shape = [n_unique_labels]
+        F1 Gain score of the positive class in binary classification or weighted
+        average of the F1 Gain scores of each class for the multiclass task.
 
     See Also
     --------
-    fbeta_score : Compute the F-beta score.
-    precision_recall_fscore_support : Compute the precision, recall, F-score,
-        and support.
+    fbeta_gain_score : Compute the F-Gain beta score.
+    precision_recall_fgain_score_support : Compute the precision gain, recall
+        gain, F-Gain score, and support.
     jaccard_score : Compute the Jaccard similarity coefficient score.
     multilabel_confusion_matrix : Compute a confusion matrix for each class or
         sample.
@@ -3225,7 +3224,10 @@ def f1_gain_score(
 
     References
     ----------
-    .. [1] `Wikipedia entry for the F1-score
+    .. [1] `Precision-Recall-Gain Curves: PR Analysis Done Right (2015) by
+            Peter A. Flach and Meelis Kull
+           <https://papers.nips.cc/paper/2015/file/33e8075e9970de0cfea955afd4644bb2-Paper.pdf>`_.
+    .. [2] `Wikipedia entry for the F1-score
            <https://en.wikipedia.org/wiki/F1_score>`_.
 
     Examples
@@ -3276,12 +3278,13 @@ def fbeta_gain_score(
     zero_division="warn",
     class_distribution=None,
 ):
-    """Compute the F-beta score.
+    """Compute the F-Gain beta score.
 
-    The F-beta score is the weighted harmonic mean of precision and recall,
-    reaching its optimal value at 1 and its worst value at 0.
+    The F-Gain beta score is the weighted arthimetic mean of precision gain
+    and recall gain, reaching its optimal value at 1 and its worst value at
+    -Inf.
 
-    The `beta` parameter determines the weight of recall in the combined
+    The `beta` parameter determines the weight of recall gain in the combined
     score. ``beta < 1`` lends more weight to precision, while ``beta > 1``
     favors recall (``beta -> 0`` considers only precision, ``beta -> +inf``
     only recall).
@@ -3356,15 +3359,15 @@ def fbeta_gain_score(
 
     Returns
     -------
-    fbeta_score : float (if average is not None) or array of float, shape =\
+    fgain_beta_score : float (if average is not None) or array of float, shape =\
         [n_unique_labels]
-        F-beta score of the positive class in binary classification or weighted
-        average of the F-beta score of each class for the multiclass task.
+        F-Gain beta score of the positive class in binary classification or weighted
+        average of the F-Gain beta score of each class for the multiclass task.
 
     See Also
     --------
-    precision_recall_fscore_support : Compute the precision, recall, F-score,
-        and support.
+    precision_recall_fgain_score_support : Compute the precision gain, recall
+        gain, F-Gain score, and support.
     multilabel_confusion_matrix : Compute a confusion matrix for each class or
         sample.
 
@@ -3377,10 +3380,13 @@ def fbeta_gain_score(
 
     References
     ----------
-    .. [1] R. Baeza-Yates and B. Ribeiro-Neto (2011).
+    .. [1] `Precision-Recall-Gain Curves: PR Analysis Done Right (2015) by
+            Peter A. Flach and Meelis Kull
+           <https://papers.nips.cc/paper/2015/file/33e8075e9970de0cfea955afd4644bb2-Paper.pdf>`_.
+    .. [2] R. Baeza-Yates and B. Ribeiro-Neto (2011).
            Modern Information Retrieval. Addison Wesley, pp. 327-328.
 
-    .. [2] `Wikipedia entry for the F1-score
+    .. [3] `Wikipedia entry for the F1-score
            <https://en.wikipedia.org/wiki/F1_score>`_.
 
     Examples
@@ -3426,29 +3432,41 @@ def precision_recall_fgain_score_support(
     sample_weight=None,
     zero_division="warn",
 ):
-    """Compute precision, recall, F-measure and support for each class.
+    """Compute precision gain, recall gain, F-Gain measure and support for each
+    class.
 
-    The precision is the ratio ``tp / (tp + fp)`` where ``tp`` is the number of
-    true positives and ``fp`` the number of false positives. The precision is
-    intuitively the ability of the classifier not to label a negative sample as
-    positive.
+    All three measures are derrived by applying the following transform to their
+    respective vanilla metric values.
 
-    The recall is the ratio ``tp / (tp + fn)`` where ``tp`` is the number of
-    true positives and ``fn`` the number of false negatives. The recall is
-    intuitively the ability of the classifier to find all the positive samples.
+        f(x) = (x - pi) / ((1 - pi) * x)
 
-    The F-beta score can be interpreted as a weighted harmonic mean of
-    the precision and recall, where an F-beta score reaches its best
-    value at 1 and worst score at 0.
+            pi = proportion of positives
 
-    The F-beta score weights recall more than precision by a factor of
-    ``beta``. ``beta == 1.0`` means recall and precision are equally important.
+    The vanilla metrics prior to transformation are defined as follows:
+
+        The precision is the ratio ``tp / (tp + fp)`` where ``tp`` is the number
+        of true positives and ``fp`` the number of false positives. The
+        precision is intuitively the ability of the classifier not to label a
+        negative sample as positive.
+
+        The recall is the ratio ``tp / (tp + fn)`` where ``tp`` is the number of
+        true positives and ``fn`` the number of false negatives. The recall is
+        intuitively the ability of the classifier to find all the positive
+        samples.
+
+        The F-beta score can be interpreted as a weighted harmonic mean of the
+        precision and recall, where an F-beta score reaches its best value at 1
+        and worst score at 0.
+
+        The F-beta score weights recall more than precision by a factor of
+        ``beta``. ``beta == 1.0`` means recall and precision are equally
+        important.
 
     The support is the number of occurrences of each class in ``y_true``.
 
-    If ``pos_label is None`` and in binary classification, this function
-    returns the average precision, recall and F-measure if ``average``
-    is one of ``'micro'``, ``'macro'``, ``'weighted'`` or ``'samples'``.
+    If ``pos_label is None`` and in binary classification, this function returns
+    the average precision gain, recall gain and F-gain measure if ``average`` is
+    one of ``'micro'``, ``'macro'``, ``'weighted'`` or ``'samples'``.
 
     Read more in the :ref:`User Guide <precision_recall_f_measure_metrics>`.
 
@@ -3523,17 +3541,17 @@ def precision_recall_fgain_score_support(
 
     Returns
     -------
-    precision : float (if average is not None) or array of float, shape =\
+    precision_gain : float (if average is not None) or array of float, shape =\
         [n_unique_labels]
-        Precision score.
+        Precision Gain score.
 
-    recall : float (if average is not None) or array of float, shape =\
+    recall_gain : float (if average is not None) or array of float, shape =\
         [n_unique_labels]
-        Recall score.
+        Recall Gain score.
 
-    fbeta_score : float (if average is not None) or array of float, shape =\
+    f_gain_beta_score : float (if average is not None) or array of float, shape =\
         [n_unique_labels]
-        F-beta score.
+        F-beta Gain score.
 
     support : None (if average is not None) or array of int, shape =\
         [n_unique_labels]
@@ -3549,14 +3567,17 @@ def precision_recall_fgain_score_support(
 
     References
     ----------
-    .. [1] `Wikipedia entry for the Precision and recall
+    .. [1] `Precision-Recall-Gain Curves: PR Analysis Done Right (2015) by Peter
+            A. Flach and Meelis Kull
+           <https://papers.nips.cc/paper/2015/file/33e8075e9970de0cfea955afd4644bb2-Paper.pdf>`_.
+    .. [2] `Wikipedia entry for the Precision and recall
            <https://en.wikipedia.org/wiki/Precision_and_recall>`_.
 
-    .. [2] `Wikipedia entry for the F1-score
+    .. [3] `Wikipedia entry for the F1-score
            <https://en.wikipedia.org/wiki/F1_score>`_.
 
-    .. [3] `Discriminative Methods for Multi-labeled Classification Advances
-           in Knowledge Discovery and Data Mining (2004), pp. 22-30 by Shantanu
+    .. [4] `Discriminative Methods for Multi-labeled Classification Advances in
+           Knowledge Discovery and Data Mining (2004), pp. 22-30 by Shantanu
            Godbole, Sunita Sarawagi
            <http://www.godbole.net/shantanu/pubs/multilabelsvm-pakdd04.pdf>`_.
 
@@ -3612,14 +3633,20 @@ def precision_gain_score(
     zero_division="warn",
     class_distribution=None,
 ):
-    """Compute the precision.
+    """Compute the precision Gain.
+
+    The metric is derrived by applying the following transform to precision:
+
+        f(x) = (x - pi) / ((1 - pi) * x)
+
+            pi = proportion of positives
 
     The precision is the ratio ``tp / (tp + fp)`` where ``tp`` is the number of
     true positives and ``fp`` the number of false positives. The precision is
     intuitively the ability of the classifier not to label as positive a sample
     that is negative.
 
-    The best value is 1 and the worst value is 0.
+    The best value is 1 and the worst value is -Inf.
 
     Read more in the :ref:`User Guide <precision_recall_f_measure_metrics>`.
 
@@ -3687,16 +3714,16 @@ def precision_gain_score(
 
     Returns
     -------
-    precision : float (if average is not None) or array of float of shape \
+    precision_gain : float (if average is not None) or array of float of shape \
                 (n_unique_labels,)
         Precision of the positive class in binary classification or weighted
         average of the precision of each class for the multiclass task.
 
     See Also
     --------
-    precision_recall_fscore_support : Compute precision, recall, F-measure and
+    precision_recall_fgain_score_support : Compute precision, recall, F-measure and
         support for each class.
-    recall_score :  Compute the ratio ``tp / (tp + fn)`` where ``tp`` is the
+    recall_gain_score :  Compute the ratio ``tp / (tp + fn)`` where ``tp`` is the
         number of true positives and ``fn`` the number of false negatives.
     PrecisionRecallDisplay.from_estimator : Plot precision-recall curve given
         an estimator and some data.
@@ -3710,6 +3737,12 @@ def precision_gain_score(
     When ``true positive + false positive == 0``, precision returns 0 and
     raises ``UndefinedMetricWarning``. This behavior can be
     modified with ``zero_division``.
+
+    References
+    ----------
+    .. [1] `Precision-Recall-Gain Curves: PR Analysis Done Right (2015) by Peter
+            A. Flach and Meelis Kull
+           <https://papers.nips.cc/paper/2015/file/33e8075e9970de0cfea955afd4644bb2-Paper.pdf>`_.
 
     Examples
     --------
@@ -3760,13 +3793,19 @@ def recall_gain_score(
     zero_division="warn",
     class_distribution=None,
 ):
-    """Compute the recall.
+    """Compute the recall Gain.
+
+    The metric is derrived by applying the following transform to precision:
+
+        f(x) = (x - pi) / ((1 - pi) * x)
+
+            pi = proportion of positives
 
     The recall is the ratio ``tp / (tp + fn)`` where ``tp`` is the number of
     true positives and ``fn`` the number of false negatives. The recall is
     intuitively the ability of the classifier to find all the positive samples.
 
-    The best value is 1 and the worst value is 0.
+    The best value is 1 and the worst value is -Inf.
 
     Read more in the :ref:`User Guide <precision_recall_f_measure_metrics>`.
 
@@ -3842,9 +3881,9 @@ def recall_gain_score(
 
     See Also
     --------
-    precision_recall_fscore_support : Compute precision, recall, F-measure and
+    precision_recall_fgain_score_support : Compute precision, recall, F-measure and
         support for each class.
-    precision_score : Compute the ratio ``tp / (tp + fp)`` where ``tp`` is the
+    precision_gain_score : Compute the ratio ``tp / (tp + fp)`` where ``tp`` is the
         number of true positives and ``fp`` the number of false positives.
     balanced_accuracy_score : Compute balanced accuracy to deal with imbalanced
         datasets.
@@ -3860,6 +3899,12 @@ def recall_gain_score(
     When ``true positive + false negative == 0``, recall returns 0 and raises
     ``UndefinedMetricWarning``. This behavior can be modified with
     ``zero_division``.
+
+    References
+    ----------
+    .. [1] `Precision-Recall-Gain Curves: PR Analysis Done Right (2015) by Peter
+            A. Flach and Meelis Kull
+           <https://papers.nips.cc/paper/2015/file/33e8075e9970de0cfea955afd4644bb2-Paper.pdf>`_.
 
     Examples
     --------
@@ -3900,5 +3945,26 @@ def recall_gain_score(
 
 
 def prg_gain_transform(x, *, pi):
-    """Transfrom from PG space into PRG space. pi = proportion positives"""
+    """Transfrom from Precision Recall space into Precision Recall Gain space.
+
+    Parameters
+    ----------
+    x : scaler or 1d array-like
+        The metric, either precision, recall or F-score to be transformed into
+        PRG space.
+    pi : scaler
+        The proportion of datapoints belonging to the positive class in the
+        dataset.
+
+    Returns
+    -------
+    x' : scaler or 1d array-like
+        The transformed metric in PRG space.
+
+    References
+    ----------
+    .. [1] `Precision-Recall-Gain Curves: PR Analysis Done Right (2015) by Peter
+            A. Flach and Meelis Kull
+           <https://papers.nips.cc/paper/2015/file/33e8075e9970de0cfea955afd4644bb2-Paper.pdf>`_.
+    """
     return (x - pi) / ((1 - pi) * x)

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -3925,4 +3925,6 @@ def prg_gain_transform(x, *, pi):
             A. Flach and Meelis Kull
            <https://papers.nips.cc/paper/2015/file/33e8075e9970de0cfea955afd4644bb2-Paper.pdf>`_.
     """
+    if x == pi == 1:
+        return 1
     return (x - pi) / ((1 - pi) * x)

--- a/sklearn/metrics/_classification.py
+++ b/sklearn/metrics/_classification.py
@@ -998,296 +998,6 @@ def zero_one_loss(y_true, y_pred, *, normalize=True, sample_weight=None):
         return n_samples - score
 
 
-def f1_gain_score(
-    y_true,
-    y_pred,
-    *,
-    labels=None,
-    pos_label=1,
-    average="binary",
-    sample_weight=None,
-    zero_division="warn",
-):
-    """Compute the F1 score, also known as balanced F-score or F-measure.
-
-    The F1 score can be interpreted as a harmonic mean of the precision and
-    recall, where an F1 score reaches its best value at 1 and worst score at 0.
-    The relative contribution of precision and recall to the F1 score are
-    equal. The formula for the F1 score is::
-
-        F1 = 2 * (precision * recall) / (precision + recall)
-
-    In the multi-class and multi-label case, this is the average of
-    the F1 score of each class with weighting depending on the ``average``
-    parameter.
-
-    Read more in the :ref:`User Guide <precision_recall_f_measure_metrics>`.
-
-    Parameters
-    ----------
-    y_true : 1d array-like, or label indicator array / sparse matrix
-        Ground truth (correct) target values.
-
-    y_pred : 1d array-like, or label indicator array / sparse matrix
-        Estimated targets as returned by a classifier.
-
-    labels : array-like, default=None
-        The set of labels to include when ``average != 'binary'``, and their
-        order if ``average is None``. Labels present in the data can be
-        excluded, for example to calculate a multiclass average ignoring a
-        majority negative class, while labels not present in the data will
-        result in 0 components in a macro average. For multilabel targets,
-        labels are column indices. By default, all labels in ``y_true`` and
-        ``y_pred`` are used in sorted order.
-
-        .. versionchanged:: 0.17
-           Parameter `labels` improved for multiclass problem.
-
-    pos_label : str or int, default=1
-        The class to report if ``average='binary'`` and the data is binary.
-        If the data are multiclass or multilabel, this will be ignored;
-        setting ``labels=[pos_label]`` and ``average != 'binary'`` will report
-        scores for that label only.
-
-    average : {'micro', 'macro', 'samples', 'weighted', 'binary'} or None, \
-            default='binary'
-        This parameter is required for multiclass/multilabel targets.
-        If ``None``, the scores for each class are returned. Otherwise, this
-        determines the type of averaging performed on the data:
-
-        ``'binary'``:
-            Only report results for the class specified by ``pos_label``.
-            This is applicable only if targets (``y_{true,pred}``) are binary.
-        ``'micro'``:
-            Calculate metrics globally by counting the total true positives,
-            false negatives and false positives.
-        ``'macro'``:
-            Calculate metrics for each label, and find their unweighted
-            mean.  This does not take label imbalance into account.
-        ``'weighted'``:
-            Calculate metrics for each label, and find their average weighted
-            by support (the number of true instances for each label). This
-            alters 'macro' to account for label imbalance; it can result in an
-            F-score that is not between precision and recall.
-        ``'samples'``:
-            Calculate metrics for each instance, and find their average (only
-            meaningful for multilabel classification where this differs from
-            :func:`accuracy_score`).
-
-    sample_weight : array-like of shape (n_samples,), default=None
-        Sample weights.
-
-    zero_division : "warn", 0 or 1, default="warn"
-        Sets the value to return when there is a zero division, i.e. when all
-        predictions and labels are negative. If set to "warn", this acts as 0,
-        but warnings are also raised.
-
-    Returns
-    -------
-    f1_score : float or array of float, shape = [n_unique_labels]
-        F1 score of the positive class in binary classification or weighted
-        average of the F1 scores of each class for the multiclass task.
-
-    See Also
-    --------
-    fbeta_score : Compute the F-beta score.
-    precision_recall_fscore_support : Compute the precision, recall, F-score,
-        and support.
-    jaccard_score : Compute the Jaccard similarity coefficient score.
-    multilabel_confusion_matrix : Compute a confusion matrix for each class or
-        sample.
-
-    Notes
-    -----
-    When ``true positive + false positive == 0``, precision is undefined.
-    When ``true positive + false negative == 0``, recall is undefined.
-    In such cases, by default the metric will be set to 0, as will f-score,
-    and ``UndefinedMetricWarning`` will be raised. This behavior can be
-    modified with ``zero_division``.
-
-    References
-    ----------
-    .. [1] `Wikipedia entry for the F1-score
-           <https://en.wikipedia.org/wiki/F1_score>`_.
-
-    Examples
-    --------
-    >>> from sklearn.metrics import f1_score
-    >>> y_true = [0, 1, 2, 0, 1, 2]
-    >>> y_pred = [0, 2, 1, 0, 0, 1]
-    >>> f1_score(y_true, y_pred, average='macro')
-    0.26...
-    >>> f1_score(y_true, y_pred, average='micro')
-    0.33...
-    >>> f1_score(y_true, y_pred, average='weighted')
-    0.26...
-    >>> f1_score(y_true, y_pred, average=None)
-    array([0.8, 0. , 0. ])
-    >>> y_true = [0, 0, 0, 0, 0, 0]
-    >>> y_pred = [0, 0, 0, 0, 0, 0]
-    >>> f1_score(y_true, y_pred, zero_division=1)
-    1.0...
-    >>> # multilabel classification
-    >>> y_true = [[0, 0, 0], [1, 1, 1], [0, 1, 1]]
-    >>> y_pred = [[0, 0, 0], [1, 1, 1], [1, 1, 0]]
-    >>> f1_score(y_true, y_pred, average=None)
-    array([0.66666667, 1.        , 0.66666667])
-    """
-    return fbeta_gain_score(
-        y_true,
-        y_pred,
-        beta=1,
-        labels=labels,
-        pos_label=pos_label,
-        average=average,
-        sample_weight=sample_weight,
-        zero_division=zero_division,
-    )
-
-
-def fbeta_gain_score(
-    y_true,
-    y_pred,
-    *,
-    beta,
-    labels=None,
-    pos_label=1,
-    average="binary",
-    sample_weight=None,
-    zero_division="warn",
-):
-    """Compute the F-beta score.
-
-    The F-beta score is the weighted harmonic mean of precision and recall,
-    reaching its optimal value at 1 and its worst value at 0.
-
-    The `beta` parameter determines the weight of recall in the combined
-    score. ``beta < 1`` lends more weight to precision, while ``beta > 1``
-    favors recall (``beta -> 0`` considers only precision, ``beta -> +inf``
-    only recall).
-
-    Read more in the :ref:`User Guide <precision_recall_f_measure_metrics>`.
-
-    Parameters
-    ----------
-    y_true : 1d array-like, or label indicator array / sparse matrix
-        Ground truth (correct) target values.
-
-    y_pred : 1d array-like, or label indicator array / sparse matrix
-        Estimated targets as returned by a classifier.
-
-    beta : float
-        Determines the weight of recall in the combined score.
-
-    labels : array-like, default=None
-        The set of labels to include when ``average != 'binary'``, and their
-        order if ``average is None``. Labels present in the data can be
-        excluded, for example to calculate a multiclass average ignoring a
-        majority negative class, while labels not present in the data will
-        result in 0 components in a macro average. For multilabel targets,
-        labels are column indices. By default, all labels in ``y_true`` and
-        ``y_pred`` are used in sorted order.
-
-        .. versionchanged:: 0.17
-           Parameter `labels` improved for multiclass problem.
-
-    pos_label : str or int, default=1
-        The class to report if ``average='binary'`` and the data is binary.
-        If the data are multiclass or multilabel, this will be ignored;
-        setting ``labels=[pos_label]`` and ``average != 'binary'`` will report
-        scores for that label only.
-
-    average : {'micro', 'macro', 'samples', 'weighted', 'binary'} or None, \
-            default='binary'
-        This parameter is required for multiclass/multilabel targets.
-        If ``None``, the scores for each class are returned. Otherwise, this
-        determines the type of averaging performed on the data:
-
-        ``'binary'``:
-            Only report results for the class specified by ``pos_label``.
-            This is applicable only if targets (``y_{true,pred}``) are binary.
-        ``'micro'``:
-            Calculate metrics globally by counting the total true positives,
-            false negatives and false positives.
-        ``'macro'``:
-            Calculate metrics for each label, and find their unweighted
-            mean.  This does not take label imbalance into account.
-        ``'weighted'``:
-            Calculate metrics for each label, and find their average weighted
-            by support (the number of true instances for each label). This
-            alters 'macro' to account for label imbalance; it can result in an
-            F-score that is not between precision and recall.
-        ``'samples'``:
-            Calculate metrics for each instance, and find their average (only
-            meaningful for multilabel classification where this differs from
-            :func:`accuracy_score`).
-
-    sample_weight : array-like of shape (n_samples,), default=None
-        Sample weights.
-
-    zero_division : "warn", 0 or 1, default="warn"
-        Sets the value to return when there is a zero division, i.e. when all
-        predictions and labels are negative. If set to "warn", this acts as 0,
-        but warnings are also raised.
-
-    Returns
-    -------
-    fbeta_score : float (if average is not None) or array of float, shape =\
-        [n_unique_labels]
-        F-beta score of the positive class in binary classification or weighted
-        average of the F-beta score of each class for the multiclass task.
-
-    See Also
-    --------
-    precision_recall_fscore_support : Compute the precision, recall, F-score,
-        and support.
-    multilabel_confusion_matrix : Compute a confusion matrix for each class or
-        sample.
-
-    Notes
-    -----
-    When ``true positive + false positive == 0`` or
-    ``true positive + false negative == 0``, f-score returns 0 and raises
-    ``UndefinedMetricWarning``. This behavior can be
-    modified with ``zero_division``.
-
-    References
-    ----------
-    .. [1] R. Baeza-Yates and B. Ribeiro-Neto (2011).
-           Modern Information Retrieval. Addison Wesley, pp. 327-328.
-
-    .. [2] `Wikipedia entry for the F1-score
-           <https://en.wikipedia.org/wiki/F1_score>`_.
-
-    Examples
-    --------
-    >>> from sklearn.metrics import fbeta_score
-    >>> y_true = [0, 1, 2, 0, 1, 2]
-    >>> y_pred = [0, 2, 1, 0, 0, 1]
-    >>> fbeta_score(y_true, y_pred, average='macro', beta=0.5)
-    0.23...
-    >>> fbeta_score(y_true, y_pred, average='micro', beta=0.5)
-    0.33...
-    >>> fbeta_score(y_true, y_pred, average='weighted', beta=0.5)
-    0.23...
-    >>> fbeta_score(y_true, y_pred, average=None, beta=0.5)
-    array([0.71..., 0.        , 0.        ])
-    """
-
-    _, _, f, _ = precision_recall_fgain_score_support(
-        y_true,
-        y_pred,
-        beta=beta,
-        labels=labels,
-        pos_label=pos_label,
-        average=average,
-        warn_for=("f-score",),
-        sample_weight=sample_weight,
-        zero_division=zero_division,
-    )
-    return f
-
-
 def f1_score(
     y_true,
     y_pred,
@@ -1681,44 +1391,6 @@ def _check_set_wise_labels(y_true, y_pred, average, labels, pos_label):
             UserWarning,
         )
     return labels
-
-
-def prg_gain_transform(x, *, pi):
-    """pi = proportion positives"""
-    return (x - pi) / ((1 - pi) * x)
-
-
-def precision_recall_fgain_score_support(
-    y_true,
-    y_pred,
-    *,
-    proportion_positives=None,
-    beta=1.0,
-    labels=None,
-    pos_label=1,
-    average=None,
-    warn_for=("precision", "recall", "f-score"),
-    sample_weight=None,
-    zero_division="warn",
-):
-    """TODO"""
-    average_options = (None, "binary", "macro", "weighted", "samples")
-    if average not in average_options:
-        raise ValueError("average has to be one of " + str(average_options))
-
-    return _precision_recall_fscore_support(
-        y_true=y_true,
-        y_pred=y_pred,
-        beta=beta,
-        labels=labels,
-        pos_label=pos_label,
-        average=average,
-        warn_for=warn_for,
-        sample_weight=sample_weight,
-        zero_division=zero_division,
-        return_in_gain_space=True,
-        proportion_positives=proportion_positives,
-    )
 
 
 def precision_recall_fscore_support(
@@ -2338,292 +2010,6 @@ def class_likelihood_ratios(
             negative_likelihood_ratio = neg_num / neg_denom
 
     return positive_likelihood_ratio, negative_likelihood_ratio
-
-
-def precision_gain_score(
-    y_true,
-    y_pred,
-    *,
-    labels=None,
-    pos_label=1,
-    average="binary",
-    sample_weight=None,
-    zero_division="warn",
-):
-    """Compute the precision.
-
-    The precision is the ratio ``tp / (tp + fp)`` where ``tp`` is the number of
-    true positives and ``fp`` the number of false positives. The precision is
-    intuitively the ability of the classifier not to label as positive a sample
-    that is negative.
-
-    The best value is 1 and the worst value is 0.
-
-    Read more in the :ref:`User Guide <precision_recall_f_measure_metrics>`.
-
-    Parameters
-    ----------
-    y_true : 1d array-like, or label indicator array / sparse matrix
-        Ground truth (correct) target values.
-
-    y_pred : 1d array-like, or label indicator array / sparse matrix
-        Estimated targets as returned by a classifier.
-
-    labels : array-like, default=None
-        The set of labels to include when ``average != 'binary'``, and their
-        order if ``average is None``. Labels present in the data can be
-        excluded, for example to calculate a multiclass average ignoring a
-        majority negative class, while labels not present in the data will
-        result in 0 components in a macro average. For multilabel targets,
-        labels are column indices. By default, all labels in ``y_true`` and
-        ``y_pred`` are used in sorted order.
-
-        .. versionchanged:: 0.17
-           Parameter `labels` improved for multiclass problem.
-
-    pos_label : str or int, default=1
-        The class to report if ``average='binary'`` and the data is binary.
-        If the data are multiclass or multilabel, this will be ignored;
-        setting ``labels=[pos_label]`` and ``average != 'binary'`` will report
-        scores for that label only.
-
-    average : {'micro', 'macro', 'samples', 'weighted', 'binary'} or None, \
-            default='binary'
-        This parameter is required for multiclass/multilabel targets.
-        If ``None``, the scores for each class are returned. Otherwise, this
-        determines the type of averaging performed on the data:
-
-        ``'binary'``:
-            Only report results for the class specified by ``pos_label``.
-            This is applicable only if targets (``y_{true,pred}``) are binary.
-        ``'micro'``:
-            Calculate metrics globally by counting the total true positives,
-            false negatives and false positives.
-        ``'macro'``:
-            Calculate metrics for each label, and find their unweighted
-            mean.  This does not take label imbalance into account.
-        ``'weighted'``:
-            Calculate metrics for each label, and find their average weighted
-            by support (the number of true instances for each label). This
-            alters 'macro' to account for label imbalance; it can result in an
-            F-score that is not between precision and recall.
-        ``'samples'``:
-            Calculate metrics for each instance, and find their average (only
-            meaningful for multilabel classification where this differs from
-            :func:`accuracy_score`).
-
-    sample_weight : array-like of shape (n_samples,), default=None
-        Sample weights.
-
-    zero_division : "warn", 0 or 1, default="warn"
-        Sets the value to return when there is a zero division. If set to
-        "warn", this acts as 0, but warnings are also raised.
-
-    Returns
-    -------
-    precision : float (if average is not None) or array of float of shape \
-                (n_unique_labels,)
-        Precision of the positive class in binary classification or weighted
-        average of the precision of each class for the multiclass task.
-
-    See Also
-    --------
-    precision_recall_fscore_support : Compute precision, recall, F-measure and
-        support for each class.
-    recall_score :  Compute the ratio ``tp / (tp + fn)`` where ``tp`` is the
-        number of true positives and ``fn`` the number of false negatives.
-    PrecisionRecallDisplay.from_estimator : Plot precision-recall curve given
-        an estimator and some data.
-    PrecisionRecallDisplay.from_predictions : Plot precision-recall curve given
-        binary class predictions.
-    multilabel_confusion_matrix : Compute a confusion matrix for each class or
-        sample.
-
-    Notes
-    -----
-    When ``true positive + false positive == 0``, precision returns 0 and
-    raises ``UndefinedMetricWarning``. This behavior can be
-    modified with ``zero_division``.
-
-    Examples
-    --------
-    >>> from sklearn.metrics import precision_score
-    >>> y_true = [0, 1, 2, 0, 1, 2]
-    >>> y_pred = [0, 2, 1, 0, 0, 1]
-    >>> precision_score(y_true, y_pred, average='macro')
-    0.22...
-    >>> precision_score(y_true, y_pred, average='micro')
-    0.33...
-    >>> precision_score(y_true, y_pred, average='weighted')
-    0.22...
-    >>> precision_score(y_true, y_pred, average=None)
-    array([0.66..., 0.        , 0.        ])
-    >>> y_pred = [0, 0, 0, 0, 0, 0]
-    >>> precision_score(y_true, y_pred, average=None)
-    array([0.33..., 0.        , 0.        ])
-    >>> precision_score(y_true, y_pred, average=None, zero_division=1)
-    array([0.33..., 1.        , 1.        ])
-    >>> # multilabel classification
-    >>> y_true = [[0, 0, 0], [1, 1, 1], [0, 1, 1]]
-    >>> y_pred = [[0, 0, 0], [1, 1, 1], [1, 1, 0]]
-    >>> precision_score(y_true, y_pred, average=None)
-    array([0.5, 1. , 1. ])
-    """
-    p, _, _, _ = precision_recall_fgain_score_support(
-        y_true,
-        y_pred,
-        labels=labels,
-        pos_label=pos_label,
-        average=average,
-        warn_for=("precision",),
-        sample_weight=sample_weight,
-        zero_division=zero_division,
-    )
-    return p
-
-
-def recall_gain_score(
-    y_true,
-    y_pred,
-    *,
-    labels=None,
-    pos_label=1,
-    average="binary",
-    sample_weight=None,
-    zero_division="warn",
-):
-    """Compute the recall.
-
-    The recall is the ratio ``tp / (tp + fn)`` where ``tp`` is the number of
-    true positives and ``fn`` the number of false negatives. The recall is
-    intuitively the ability of the classifier to find all the positive samples.
-
-    The best value is 1 and the worst value is 0.
-
-    Read more in the :ref:`User Guide <precision_recall_f_measure_metrics>`.
-
-    Parameters
-    ----------
-    y_true : 1d array-like, or label indicator array / sparse matrix
-        Ground truth (correct) target values.
-
-    y_pred : 1d array-like, or label indicator array / sparse matrix
-        Estimated targets as returned by a classifier.
-
-    labels : array-like, default=None
-        The set of labels to include when ``average != 'binary'``, and their
-        order if ``average is None``. Labels present in the data can be
-        excluded, for example to calculate a multiclass average ignoring a
-        majority negative class, while labels not present in the data will
-        result in 0 components in a macro average. For multilabel targets,
-        labels are column indices. By default, all labels in ``y_true`` and
-        ``y_pred`` are used in sorted order.
-
-        .. versionchanged:: 0.17
-           Parameter `labels` improved for multiclass problem.
-
-    pos_label : str or int, default=1
-        The class to report if ``average='binary'`` and the data is binary.
-        If the data are multiclass or multilabel, this will be ignored;
-        setting ``labels=[pos_label]`` and ``average != 'binary'`` will report
-        scores for that label only.
-
-    average : {'micro', 'macro', 'samples', 'weighted', 'binary'} or None, \
-            default='binary'
-        This parameter is required for multiclass/multilabel targets.
-        If ``None``, the scores for each class are returned. Otherwise, this
-        determines the type of averaging performed on the data:
-
-        ``'binary'``:
-            Only report results for the class specified by ``pos_label``.
-            This is applicable only if targets (``y_{true,pred}``) are binary.
-        ``'micro'``:
-            Calculate metrics globally by counting the total true positives,
-            false negatives and false positives.
-        ``'macro'``:
-            Calculate metrics for each label, and find their unweighted
-            mean.  This does not take label imbalance into account.
-        ``'weighted'``:
-            Calculate metrics for each label, and find their average weighted
-            by support (the number of true instances for each label). This
-            alters 'macro' to account for label imbalance; it can result in an
-            F-score that is not between precision and recall. Weighted recall
-            is equal to accuracy.
-        ``'samples'``:
-            Calculate metrics for each instance, and find their average (only
-            meaningful for multilabel classification where this differs from
-            :func:`accuracy_score`).
-
-    sample_weight : array-like of shape (n_samples,), default=None
-        Sample weights.
-
-    zero_division : "warn", 0 or 1, default="warn"
-        Sets the value to return when there is a zero division. If set to
-        "warn", this acts as 0, but warnings are also raised.
-
-    Returns
-    -------
-    recall : float (if average is not None) or array of float of shape \
-             (n_unique_labels,)
-        Recall of the positive class in binary classification or weighted
-        average of the recall of each class for the multiclass task.
-
-    See Also
-    --------
-    precision_recall_fscore_support : Compute precision, recall, F-measure and
-        support for each class.
-    precision_score : Compute the ratio ``tp / (tp + fp)`` where ``tp`` is the
-        number of true positives and ``fp`` the number of false positives.
-    balanced_accuracy_score : Compute balanced accuracy to deal with imbalanced
-        datasets.
-    multilabel_confusion_matrix : Compute a confusion matrix for each class or
-        sample.
-    PrecisionRecallDisplay.from_estimator : Plot precision-recall curve given
-        an estimator and some data.
-    PrecisionRecallDisplay.from_predictions : Plot precision-recall curve given
-        binary class predictions.
-
-    Notes
-    -----
-    When ``true positive + false negative == 0``, recall returns 0 and raises
-    ``UndefinedMetricWarning``. This behavior can be modified with
-    ``zero_division``.
-
-    Examples
-    --------
-    >>> from sklearn.metrics import recall_score
-    >>> y_true = [0, 1, 2, 0, 1, 2]
-    >>> y_pred = [0, 2, 1, 0, 0, 1]
-    >>> recall_score(y_true, y_pred, average='macro')
-    0.33...
-    >>> recall_score(y_true, y_pred, average='micro')
-    0.33...
-    >>> recall_score(y_true, y_pred, average='weighted')
-    0.33...
-    >>> recall_score(y_true, y_pred, average=None)
-    array([1., 0., 0.])
-    >>> y_true = [0, 0, 0, 0, 0, 0]
-    >>> recall_score(y_true, y_pred, average=None)
-    array([0.5, 0. , 0. ])
-    >>> recall_score(y_true, y_pred, average=None, zero_division=1)
-    array([0.5, 1. , 1. ])
-    >>> # multilabel classification
-    >>> y_true = [[0, 0, 0], [1, 1, 1], [0, 1, 1]]
-    >>> y_pred = [[0, 0, 0], [1, 1, 1], [1, 1, 0]]
-    >>> recall_score(y_true, y_pred, average=None)
-    array([1. , 1. , 0.5])
-    """
-    _, r, _, _ = precision_recall_fgain_score_support(
-        y_true,
-        y_pred,
-        labels=labels,
-        pos_label=pos_label,
-        average=average,
-        warn_for=("recall",),
-        sample_weight=sample_weight,
-        zero_division=zero_division,
-    )
-    return r
 
 
 def precision_score(
@@ -3693,3 +3079,617 @@ def brier_score_loss(y_true, y_prob, *, sample_weight=None, pos_label=None):
             raise
     y_true = np.array(y_true == pos_label, int)
     return np.average((y_true - y_prob) ** 2, weights=sample_weight)
+
+
+def f1_gain_score(
+    y_true,
+    y_pred,
+    *,
+    labels=None,
+    pos_label=1,
+    average="binary",
+    sample_weight=None,
+    zero_division="warn",
+):
+    """Compute the F1 score, also known as balanced F-score or F-measure.
+
+    The F1 score can be interpreted as a harmonic mean of the precision and
+    recall, where an F1 score reaches its best value at 1 and worst score at 0.
+    The relative contribution of precision and recall to the F1 score are
+    equal. The formula for the F1 score is::
+
+        F1 = 2 * (precision * recall) / (precision + recall)
+
+    In the multi-class and multi-label case, this is the average of
+    the F1 score of each class with weighting depending on the ``average``
+    parameter.
+
+    Read more in the :ref:`User Guide <precision_recall_f_measure_metrics>`.
+
+    Parameters
+    ----------
+    y_true : 1d array-like, or label indicator array / sparse matrix
+        Ground truth (correct) target values.
+
+    y_pred : 1d array-like, or label indicator array / sparse matrix
+        Estimated targets as returned by a classifier.
+
+    labels : array-like, default=None
+        The set of labels to include when ``average != 'binary'``, and their
+        order if ``average is None``. Labels present in the data can be
+        excluded, for example to calculate a multiclass average ignoring a
+        majority negative class, while labels not present in the data will
+        result in 0 components in a macro average. For multilabel targets,
+        labels are column indices. By default, all labels in ``y_true`` and
+        ``y_pred`` are used in sorted order.
+
+        .. versionchanged:: 0.17
+           Parameter `labels` improved for multiclass problem.
+
+    pos_label : str or int, default=1
+        The class to report if ``average='binary'`` and the data is binary.
+        If the data are multiclass or multilabel, this will be ignored;
+        setting ``labels=[pos_label]`` and ``average != 'binary'`` will report
+        scores for that label only.
+
+    average : {'micro', 'macro', 'samples', 'weighted', 'binary'} or None, \
+            default='binary'
+        This parameter is required for multiclass/multilabel targets.
+        If ``None``, the scores for each class are returned. Otherwise, this
+        determines the type of averaging performed on the data:
+
+        ``'binary'``:
+            Only report results for the class specified by ``pos_label``.
+            This is applicable only if targets (``y_{true,pred}``) are binary.
+        ``'micro'``:
+            Calculate metrics globally by counting the total true positives,
+            false negatives and false positives.
+        ``'macro'``:
+            Calculate metrics for each label, and find their unweighted
+            mean.  This does not take label imbalance into account.
+        ``'weighted'``:
+            Calculate metrics for each label, and find their average weighted
+            by support (the number of true instances for each label). This
+            alters 'macro' to account for label imbalance; it can result in an
+            F-score that is not between precision and recall.
+        ``'samples'``:
+            Calculate metrics for each instance, and find their average (only
+            meaningful for multilabel classification where this differs from
+            :func:`accuracy_score`).
+
+    sample_weight : array-like of shape (n_samples,), default=None
+        Sample weights.
+
+    zero_division : "warn", 0 or 1, default="warn"
+        Sets the value to return when there is a zero division, i.e. when all
+        predictions and labels are negative. If set to "warn", this acts as 0,
+        but warnings are also raised.
+
+    Returns
+    -------
+    f1_score : float or array of float, shape = [n_unique_labels]
+        F1 score of the positive class in binary classification or weighted
+        average of the F1 scores of each class for the multiclass task.
+
+    See Also
+    --------
+    fbeta_score : Compute the F-beta score.
+    precision_recall_fscore_support : Compute the precision, recall, F-score,
+        and support.
+    jaccard_score : Compute the Jaccard similarity coefficient score.
+    multilabel_confusion_matrix : Compute a confusion matrix for each class or
+        sample.
+
+    Notes
+    -----
+    When ``true positive + false positive == 0``, precision is undefined.
+    When ``true positive + false negative == 0``, recall is undefined.
+    In such cases, by default the metric will be set to 0, as will f-score,
+    and ``UndefinedMetricWarning`` will be raised. This behavior can be
+    modified with ``zero_division``.
+
+    References
+    ----------
+    .. [1] `Wikipedia entry for the F1-score
+           <https://en.wikipedia.org/wiki/F1_score>`_.
+
+    Examples
+    --------
+    >>> from sklearn.metrics import f1_score
+    >>> y_true = [0, 1, 2, 0, 1, 2]
+    >>> y_pred = [0, 2, 1, 0, 0, 1]
+    >>> f1_score(y_true, y_pred, average='macro')
+    0.26...
+    >>> f1_score(y_true, y_pred, average='micro')
+    0.33...
+    >>> f1_score(y_true, y_pred, average='weighted')
+    0.26...
+    >>> f1_score(y_true, y_pred, average=None)
+    array([0.8, 0. , 0. ])
+    >>> y_true = [0, 0, 0, 0, 0, 0]
+    >>> y_pred = [0, 0, 0, 0, 0, 0]
+    >>> f1_score(y_true, y_pred, zero_division=1)
+    1.0...
+    >>> # multilabel classification
+    >>> y_true = [[0, 0, 0], [1, 1, 1], [0, 1, 1]]
+    >>> y_pred = [[0, 0, 0], [1, 1, 1], [1, 1, 0]]
+    >>> f1_score(y_true, y_pred, average=None)
+    array([0.66666667, 1.        , 0.66666667])
+    """
+    return fbeta_gain_score(
+        y_true,
+        y_pred,
+        beta=1,
+        labels=labels,
+        pos_label=pos_label,
+        average=average,
+        sample_weight=sample_weight,
+        zero_division=zero_division,
+    )
+
+
+def fbeta_gain_score(
+    y_true,
+    y_pred,
+    *,
+    beta,
+    labels=None,
+    pos_label=1,
+    average="binary",
+    sample_weight=None,
+    zero_division="warn",
+):
+    """Compute the F-beta score.
+
+    The F-beta score is the weighted harmonic mean of precision and recall,
+    reaching its optimal value at 1 and its worst value at 0.
+
+    The `beta` parameter determines the weight of recall in the combined
+    score. ``beta < 1`` lends more weight to precision, while ``beta > 1``
+    favors recall (``beta -> 0`` considers only precision, ``beta -> +inf``
+    only recall).
+
+    Read more in the :ref:`User Guide <precision_recall_f_measure_metrics>`.
+
+    Parameters
+    ----------
+    y_true : 1d array-like, or label indicator array / sparse matrix
+        Ground truth (correct) target values.
+
+    y_pred : 1d array-like, or label indicator array / sparse matrix
+        Estimated targets as returned by a classifier.
+
+    beta : float
+        Determines the weight of recall in the combined score.
+
+    labels : array-like, default=None
+        The set of labels to include when ``average != 'binary'``, and their
+        order if ``average is None``. Labels present in the data can be
+        excluded, for example to calculate a multiclass average ignoring a
+        majority negative class, while labels not present in the data will
+        result in 0 components in a macro average. For multilabel targets,
+        labels are column indices. By default, all labels in ``y_true`` and
+        ``y_pred`` are used in sorted order.
+
+        .. versionchanged:: 0.17
+           Parameter `labels` improved for multiclass problem.
+
+    pos_label : str or int, default=1
+        The class to report if ``average='binary'`` and the data is binary.
+        If the data are multiclass or multilabel, this will be ignored;
+        setting ``labels=[pos_label]`` and ``average != 'binary'`` will report
+        scores for that label only.
+
+    average : {'micro', 'macro', 'samples', 'weighted', 'binary'} or None, \
+            default='binary'
+        This parameter is required for multiclass/multilabel targets.
+        If ``None``, the scores for each class are returned. Otherwise, this
+        determines the type of averaging performed on the data:
+
+        ``'binary'``:
+            Only report results for the class specified by ``pos_label``.
+            This is applicable only if targets (``y_{true,pred}``) are binary.
+        ``'micro'``:
+            Calculate metrics globally by counting the total true positives,
+            false negatives and false positives.
+        ``'macro'``:
+            Calculate metrics for each label, and find their unweighted
+            mean.  This does not take label imbalance into account.
+        ``'weighted'``:
+            Calculate metrics for each label, and find their average weighted
+            by support (the number of true instances for each label). This
+            alters 'macro' to account for label imbalance; it can result in an
+            F-score that is not between precision and recall.
+        ``'samples'``:
+            Calculate metrics for each instance, and find their average (only
+            meaningful for multilabel classification where this differs from
+            :func:`accuracy_score`).
+
+    sample_weight : array-like of shape (n_samples,), default=None
+        Sample weights.
+
+    zero_division : "warn", 0 or 1, default="warn"
+        Sets the value to return when there is a zero division, i.e. when all
+        predictions and labels are negative. If set to "warn", this acts as 0,
+        but warnings are also raised.
+
+    Returns
+    -------
+    fbeta_score : float (if average is not None) or array of float, shape =\
+        [n_unique_labels]
+        F-beta score of the positive class in binary classification or weighted
+        average of the F-beta score of each class for the multiclass task.
+
+    See Also
+    --------
+    precision_recall_fscore_support : Compute the precision, recall, F-score,
+        and support.
+    multilabel_confusion_matrix : Compute a confusion matrix for each class or
+        sample.
+
+    Notes
+    -----
+    When ``true positive + false positive == 0`` or
+    ``true positive + false negative == 0``, f-score returns 0 and raises
+    ``UndefinedMetricWarning``. This behavior can be
+    modified with ``zero_division``.
+
+    References
+    ----------
+    .. [1] R. Baeza-Yates and B. Ribeiro-Neto (2011).
+           Modern Information Retrieval. Addison Wesley, pp. 327-328.
+
+    .. [2] `Wikipedia entry for the F1-score
+           <https://en.wikipedia.org/wiki/F1_score>`_.
+
+    Examples
+    --------
+    >>> from sklearn.metrics import fbeta_score
+    >>> y_true = [0, 1, 2, 0, 1, 2]
+    >>> y_pred = [0, 2, 1, 0, 0, 1]
+    >>> fbeta_score(y_true, y_pred, average='macro', beta=0.5)
+    0.23...
+    >>> fbeta_score(y_true, y_pred, average='micro', beta=0.5)
+    0.33...
+    >>> fbeta_score(y_true, y_pred, average='weighted', beta=0.5)
+    0.23...
+    >>> fbeta_score(y_true, y_pred, average=None, beta=0.5)
+    array([0.71..., 0.        , 0.        ])
+    """
+
+    _, _, f, _ = precision_recall_fgain_score_support(
+        y_true,
+        y_pred,
+        beta=beta,
+        labels=labels,
+        pos_label=pos_label,
+        average=average,
+        warn_for=("f-score",),
+        sample_weight=sample_weight,
+        zero_division=zero_division,
+    )
+    return f
+
+
+def precision_recall_fgain_score_support(
+    y_true,
+    y_pred,
+    *,
+    proportion_positives=None,
+    beta=1.0,
+    labels=None,
+    pos_label=1,
+    average=None,
+    warn_for=("precision", "recall", "f-score"),
+    sample_weight=None,
+    zero_division="warn",
+):
+    """TODO"""
+    average_options = (None, "binary", "macro", "weighted", "samples")
+    if average not in average_options:
+        raise ValueError("average has to be one of " + str(average_options))
+
+    return _precision_recall_fscore_support(
+        y_true=y_true,
+        y_pred=y_pred,
+        beta=beta,
+        labels=labels,
+        pos_label=pos_label,
+        average=average,
+        warn_for=warn_for,
+        sample_weight=sample_weight,
+        zero_division=zero_division,
+        return_in_gain_space=True,
+        proportion_positives=proportion_positives,
+    )
+
+
+def precision_gain_score(
+    y_true,
+    y_pred,
+    *,
+    labels=None,
+    pos_label=1,
+    average="binary",
+    sample_weight=None,
+    zero_division="warn",
+):
+    """Compute the precision.
+
+    The precision is the ratio ``tp / (tp + fp)`` where ``tp`` is the number of
+    true positives and ``fp`` the number of false positives. The precision is
+    intuitively the ability of the classifier not to label as positive a sample
+    that is negative.
+
+    The best value is 1 and the worst value is 0.
+
+    Read more in the :ref:`User Guide <precision_recall_f_measure_metrics>`.
+
+    Parameters
+    ----------
+    y_true : 1d array-like, or label indicator array / sparse matrix
+        Ground truth (correct) target values.
+
+    y_pred : 1d array-like, or label indicator array / sparse matrix
+        Estimated targets as returned by a classifier.
+
+    labels : array-like, default=None
+        The set of labels to include when ``average != 'binary'``, and their
+        order if ``average is None``. Labels present in the data can be
+        excluded, for example to calculate a multiclass average ignoring a
+        majority negative class, while labels not present in the data will
+        result in 0 components in a macro average. For multilabel targets,
+        labels are column indices. By default, all labels in ``y_true`` and
+        ``y_pred`` are used in sorted order.
+
+        .. versionchanged:: 0.17
+           Parameter `labels` improved for multiclass problem.
+
+    pos_label : str or int, default=1
+        The class to report if ``average='binary'`` and the data is binary.
+        If the data are multiclass or multilabel, this will be ignored;
+        setting ``labels=[pos_label]`` and ``average != 'binary'`` will report
+        scores for that label only.
+
+    average : {'micro', 'macro', 'samples', 'weighted', 'binary'} or None, \
+            default='binary'
+        This parameter is required for multiclass/multilabel targets.
+        If ``None``, the scores for each class are returned. Otherwise, this
+        determines the type of averaging performed on the data:
+
+        ``'binary'``:
+            Only report results for the class specified by ``pos_label``.
+            This is applicable only if targets (``y_{true,pred}``) are binary.
+        ``'micro'``:
+            Calculate metrics globally by counting the total true positives,
+            false negatives and false positives.
+        ``'macro'``:
+            Calculate metrics for each label, and find their unweighted
+            mean.  This does not take label imbalance into account.
+        ``'weighted'``:
+            Calculate metrics for each label, and find their average weighted
+            by support (the number of true instances for each label). This
+            alters 'macro' to account for label imbalance; it can result in an
+            F-score that is not between precision and recall.
+        ``'samples'``:
+            Calculate metrics for each instance, and find their average (only
+            meaningful for multilabel classification where this differs from
+            :func:`accuracy_score`).
+
+    sample_weight : array-like of shape (n_samples,), default=None
+        Sample weights.
+
+    zero_division : "warn", 0 or 1, default="warn"
+        Sets the value to return when there is a zero division. If set to
+        "warn", this acts as 0, but warnings are also raised.
+
+    Returns
+    -------
+    precision : float (if average is not None) or array of float of shape \
+                (n_unique_labels,)
+        Precision of the positive class in binary classification or weighted
+        average of the precision of each class for the multiclass task.
+
+    See Also
+    --------
+    precision_recall_fscore_support : Compute precision, recall, F-measure and
+        support for each class.
+    recall_score :  Compute the ratio ``tp / (tp + fn)`` where ``tp`` is the
+        number of true positives and ``fn`` the number of false negatives.
+    PrecisionRecallDisplay.from_estimator : Plot precision-recall curve given
+        an estimator and some data.
+    PrecisionRecallDisplay.from_predictions : Plot precision-recall curve given
+        binary class predictions.
+    multilabel_confusion_matrix : Compute a confusion matrix for each class or
+        sample.
+
+    Notes
+    -----
+    When ``true positive + false positive == 0``, precision returns 0 and
+    raises ``UndefinedMetricWarning``. This behavior can be
+    modified with ``zero_division``.
+
+    Examples
+    --------
+    >>> from sklearn.metrics import precision_score
+    >>> y_true = [0, 1, 2, 0, 1, 2]
+    >>> y_pred = [0, 2, 1, 0, 0, 1]
+    >>> precision_score(y_true, y_pred, average='macro')
+    0.22...
+    >>> precision_score(y_true, y_pred, average='micro')
+    0.33...
+    >>> precision_score(y_true, y_pred, average='weighted')
+    0.22...
+    >>> precision_score(y_true, y_pred, average=None)
+    array([0.66..., 0.        , 0.        ])
+    >>> y_pred = [0, 0, 0, 0, 0, 0]
+    >>> precision_score(y_true, y_pred, average=None)
+    array([0.33..., 0.        , 0.        ])
+    >>> precision_score(y_true, y_pred, average=None, zero_division=1)
+    array([0.33..., 1.        , 1.        ])
+    >>> # multilabel classification
+    >>> y_true = [[0, 0, 0], [1, 1, 1], [0, 1, 1]]
+    >>> y_pred = [[0, 0, 0], [1, 1, 1], [1, 1, 0]]
+    >>> precision_score(y_true, y_pred, average=None)
+    array([0.5, 1. , 1. ])
+    """
+    p, _, _, _ = precision_recall_fgain_score_support(
+        y_true,
+        y_pred,
+        labels=labels,
+        pos_label=pos_label,
+        average=average,
+        warn_for=("precision",),
+        sample_weight=sample_weight,
+        zero_division=zero_division,
+    )
+    return p
+
+
+def recall_gain_score(
+    y_true,
+    y_pred,
+    *,
+    labels=None,
+    pos_label=1,
+    average="binary",
+    sample_weight=None,
+    zero_division="warn",
+):
+    """Compute the recall.
+
+    The recall is the ratio ``tp / (tp + fn)`` where ``tp`` is the number of
+    true positives and ``fn`` the number of false negatives. The recall is
+    intuitively the ability of the classifier to find all the positive samples.
+
+    The best value is 1 and the worst value is 0.
+
+    Read more in the :ref:`User Guide <precision_recall_f_measure_metrics>`.
+
+    Parameters
+    ----------
+    y_true : 1d array-like, or label indicator array / sparse matrix
+        Ground truth (correct) target values.
+
+    y_pred : 1d array-like, or label indicator array / sparse matrix
+        Estimated targets as returned by a classifier.
+
+    labels : array-like, default=None
+        The set of labels to include when ``average != 'binary'``, and their
+        order if ``average is None``. Labels present in the data can be
+        excluded, for example to calculate a multiclass average ignoring a
+        majority negative class, while labels not present in the data will
+        result in 0 components in a macro average. For multilabel targets,
+        labels are column indices. By default, all labels in ``y_true`` and
+        ``y_pred`` are used in sorted order.
+
+        .. versionchanged:: 0.17
+           Parameter `labels` improved for multiclass problem.
+
+    pos_label : str or int, default=1
+        The class to report if ``average='binary'`` and the data is binary.
+        If the data are multiclass or multilabel, this will be ignored;
+        setting ``labels=[pos_label]`` and ``average != 'binary'`` will report
+        scores for that label only.
+
+    average : {'micro', 'macro', 'samples', 'weighted', 'binary'} or None, \
+            default='binary'
+        This parameter is required for multiclass/multilabel targets.
+        If ``None``, the scores for each class are returned. Otherwise, this
+        determines the type of averaging performed on the data:
+
+        ``'binary'``:
+            Only report results for the class specified by ``pos_label``.
+            This is applicable only if targets (``y_{true,pred}``) are binary.
+        ``'micro'``:
+            Calculate metrics globally by counting the total true positives,
+            false negatives and false positives.
+        ``'macro'``:
+            Calculate metrics for each label, and find their unweighted
+            mean.  This does not take label imbalance into account.
+        ``'weighted'``:
+            Calculate metrics for each label, and find their average weighted
+            by support (the number of true instances for each label). This
+            alters 'macro' to account for label imbalance; it can result in an
+            F-score that is not between precision and recall. Weighted recall
+            is equal to accuracy.
+        ``'samples'``:
+            Calculate metrics for each instance, and find their average (only
+            meaningful for multilabel classification where this differs from
+            :func:`accuracy_score`).
+
+    sample_weight : array-like of shape (n_samples,), default=None
+        Sample weights.
+
+    zero_division : "warn", 0 or 1, default="warn"
+        Sets the value to return when there is a zero division. If set to
+        "warn", this acts as 0, but warnings are also raised.
+
+    Returns
+    -------
+    recall : float (if average is not None) or array of float of shape \
+             (n_unique_labels,)
+        Recall of the positive class in binary classification or weighted
+        average of the recall of each class for the multiclass task.
+
+    See Also
+    --------
+    precision_recall_fscore_support : Compute precision, recall, F-measure and
+        support for each class.
+    precision_score : Compute the ratio ``tp / (tp + fp)`` where ``tp`` is the
+        number of true positives and ``fp`` the number of false positives.
+    balanced_accuracy_score : Compute balanced accuracy to deal with imbalanced
+        datasets.
+    multilabel_confusion_matrix : Compute a confusion matrix for each class or
+        sample.
+    PrecisionRecallDisplay.from_estimator : Plot precision-recall curve given
+        an estimator and some data.
+    PrecisionRecallDisplay.from_predictions : Plot precision-recall curve given
+        binary class predictions.
+
+    Notes
+    -----
+    When ``true positive + false negative == 0``, recall returns 0 and raises
+    ``UndefinedMetricWarning``. This behavior can be modified with
+    ``zero_division``.
+
+    Examples
+    --------
+    >>> from sklearn.metrics import recall_score
+    >>> y_true = [0, 1, 2, 0, 1, 2]
+    >>> y_pred = [0, 2, 1, 0, 0, 1]
+    >>> recall_score(y_true, y_pred, average='macro')
+    0.33...
+    >>> recall_score(y_true, y_pred, average='micro')
+    0.33...
+    >>> recall_score(y_true, y_pred, average='weighted')
+    0.33...
+    >>> recall_score(y_true, y_pred, average=None)
+    array([1., 0., 0.])
+    >>> y_true = [0, 0, 0, 0, 0, 0]
+    >>> recall_score(y_true, y_pred, average=None)
+    array([0.5, 0. , 0. ])
+    >>> recall_score(y_true, y_pred, average=None, zero_division=1)
+    array([0.5, 1. , 1. ])
+    >>> # multilabel classification
+    >>> y_true = [[0, 0, 0], [1, 1, 1], [0, 1, 1]]
+    >>> y_pred = [[0, 0, 0], [1, 1, 1], [1, 1, 0]]
+    >>> recall_score(y_true, y_pred, average=None)
+    array([1. , 1. , 0.5])
+    """
+    _, r, _, _ = precision_recall_fgain_score_support(
+        y_true,
+        y_pred,
+        labels=labels,
+        pos_label=pos_label,
+        average=average,
+        warn_for=("recall",),
+        sample_weight=sample_weight,
+        zero_division=zero_division,
+    )
+    return r
+
+
+def prg_gain_transform(x, *, pi):
+    """pi = proportion positives"""
+    return (x - pi) / ((1 - pi) * x)

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -31,15 +31,20 @@ from sklearn.metrics import classification_report
 from sklearn.metrics import cohen_kappa_score
 from sklearn.metrics import confusion_matrix
 from sklearn.metrics import f1_score
+from sklearn.metrics import f1_gain_score
 from sklearn.metrics import fbeta_score
+from sklearn.metrics import fbeta_gain_score
 from sklearn.metrics import hamming_loss
 from sklearn.metrics import hinge_loss
 from sklearn.metrics import jaccard_score
 from sklearn.metrics import log_loss
 from sklearn.metrics import matthews_corrcoef
 from sklearn.metrics import precision_recall_fscore_support
+from sklearn.metrics import precision_recall_fgain_score_support
 from sklearn.metrics import precision_score
+from sklearn.metrics import precision_gain_score
 from sklearn.metrics import recall_score
+from sklearn.metrics import recall_gain_score
 from sklearn.metrics import zero_one_loss
 from sklearn.metrics import brier_score_loss
 from sklearn.metrics import multilabel_confusion_matrix
@@ -227,6 +232,41 @@ def test_multilabel_accuracy_score_subset_accuracy():
     assert accuracy_score(y2, np.zeros(y1.shape)) == 0
 
 
+def test_precision_recall_f1_gain_score_binary():
+    # Test Precision Recall and F1 Score for binary classification task
+    y_true, y_pred, _ = make_prediction(binary=True)
+
+    # detailed measures for each class
+    p, r, f, s = precision_recall_fgain_score_support(y_true, y_pred, average=None)
+    assert_array_almost_equal(p, [0.64, 0.82], 2)
+    assert_array_almost_equal(r, [0.86, 0.53], 2)
+    assert_array_almost_equal(f, [0.75, 0.68], 2)
+    assert_array_equal(s, [25, 25])
+
+    # individual scoring function that can be used for grid search: in the
+    # binary class case the score is the value of the measure for the positive
+    # class (e.g. label == 1). This is deprecated for average != 'binary'.
+    for kwargs, my_assert in [
+        ({}, assert_no_warnings),
+        ({"average": "binary"}, assert_no_warnings),
+    ]:
+        ps = my_assert(precision_gain_score, y_true, y_pred, **kwargs)
+        assert_array_almost_equal(ps, 0.82, 2)
+
+        rs = my_assert(recall_gain_score, y_true, y_pred, **kwargs)
+        assert_array_almost_equal(rs, 0.53, 2)
+
+        fs = my_assert(f1_gain_score, y_true, y_pred, **kwargs)
+        assert_array_almost_equal(fs, 0.68, 2)
+
+        beta = 2
+        assert_almost_equal(
+            my_assert(fbeta_gain_score, y_true, y_pred, beta=beta, **kwargs),
+            (ps + ((beta**2) * rs)) / (1 + (beta**2)),
+            2,
+        )
+
+
 def test_precision_recall_f1_score_binary():
     # Test Precision Recall and F1 Score for binary classification task
     y_true, y_pred, _ = make_prediction(binary=True)
@@ -384,6 +424,11 @@ def test_average_precision_score_tied_values():
     y_true = [0, 1, 1]
     y_score = [0.5, 0.5, 0.6]
     assert average_precision_score(y_true, y_score) != 1.0
+
+
+@ignore_warnings
+def test_precision_recall_fgain_score_support_errors():
+    pass
 
 
 @ignore_warnings
@@ -907,6 +952,55 @@ def test_matthews_corrcoef_overflow(n_points):
     y_true, y_pred = random_ys(n_points)
     assert_almost_equal(matthews_corrcoef(y_true, y_true), 1.0)
     assert_almost_equal(matthews_corrcoef(y_true, y_pred), mcc_safe(y_true, y_pred))
+
+
+def test_precision_recall_f1_gain_score_multiclass():
+    # Test Precision Recall and F1 Score for multiclass classification task
+    y_true, y_pred, _ = make_prediction(binary=False)
+
+    # compute scores with default labels introspection
+    p, r, f, s = precision_recall_fgain_score_support(y_true, y_pred, average=None)
+    assert_array_almost_equal(p, [0.9, -0.41, 0.49], 2)
+    assert_array_almost_equal(r, [0.88, -5.58, 0.96], 2)
+    assert_array_almost_equal(f, [0.89, -2.99, 0.73], 2)
+    assert_array_equal(s, [24, 31, 20])
+
+    # averaging tests
+    ps = precision_gain_score(y_true, y_pred, average="macro")
+    assert_array_almost_equal(ps, 0.33, 2)
+
+    rs = recall_gain_score(y_true, y_pred, average="macro")
+    assert_array_almost_equal(rs, -1.25, 2)
+
+    fs = f1_gain_score(y_true, y_pred, average="macro")
+    assert_array_almost_equal(fs, -0.46, 2)
+
+    ps = precision_gain_score(y_true, y_pred, average="weighted")
+    assert_array_almost_equal(ps, 0.25, 2)
+
+    rs = recall_gain_score(y_true, y_pred, average="weighted")
+    assert_array_almost_equal(rs, -1.77, 2)
+
+    fs = f1_gain_score(y_true, y_pred, average="weighted")
+    assert_array_almost_equal(fs, -0.76, 2)
+
+    with pytest.raises(ValueError):
+        precision_gain_score(y_true, y_pred, average="samples")
+    with pytest.raises(ValueError):
+        recall_gain_score(y_true, y_pred, average="samples")
+    with pytest.raises(ValueError):
+        f1_gain_score(y_true, y_pred, average="samples")
+    with pytest.raises(ValueError):
+        fbeta_gain_score(y_true, y_pred, average="samples", beta=0.5)
+
+    # same prediction but with and explicit label ordering
+    p, r, f, s = precision_recall_fgain_score_support(
+        y_true, y_pred, labels=[0, 2, 1], average=None
+    )
+    assert_array_almost_equal(p, [0.9, 0.49, -0.41], 2)
+    assert_array_almost_equal(r, [0.88, 0.96, -5.58], 2)
+    assert_array_almost_equal(f, [0.89, 0.73, -2.99], 2)
+    assert_array_equal(s, [24, 20, 31])
 
 
 def test_precision_recall_f1_score_multiclass():

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -448,6 +448,18 @@ def test_precision_recall_fgain_score_support_errors():
     with pytest.raises(ValueError):
         precision_recall_fgain_score_support([0, 1, 2], [1, 2, 0], average="micro")
 
+    # Bad class_distribution dimension
+    with pytest.raises(ValueError):
+        precision_recall_fgain_score_support(
+            [0, 1, 2], [1, 2, 0], class_distribution=[3]
+        )
+
+    # Bad class_distribution values
+    with pytest.raises(ValueError):
+        precision_recall_fgain_score_support(
+            [0, 1, 2], [1, 2, 0], class_distribution=[0.4, 0.6, 0.1]
+        )
+
 
 @ignore_warnings
 def test_precision_recall_fscore_support_errors():

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -428,7 +428,25 @@ def test_average_precision_score_tied_values():
 
 @ignore_warnings
 def test_precision_recall_fgain_score_support_errors():
-    pass
+    y_true, y_pred, _ = make_prediction(binary=True)
+
+    # Bad beta
+    with pytest.raises(ValueError):
+        precision_recall_fgain_score_support(y_true, y_pred, beta=-0.1)
+
+    # Bad pos_label
+    with pytest.raises(ValueError):
+        precision_recall_fgain_score_support(
+            y_true, y_pred, pos_label=2, average="binary"
+        )
+
+    # Bad average option 1
+    with pytest.raises(ValueError):
+        precision_recall_fgain_score_support([0, 1, 2], [1, 2, 0], average="mega")
+
+    # Bad average option 2
+    with pytest.raises(ValueError):
+        precision_recall_fgain_score_support([0, 1, 2], [1, 2, 0], average="micro")
 
 
 @ignore_warnings

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -232,6 +232,66 @@ def test_multilabel_accuracy_score_subset_accuracy():
     assert accuracy_score(y2, np.zeros(y1.shape)) == 0
 
 
+def test_precision_recall_f1_gain_score_averages():
+    # Test Precision Recall and F1 Score for binary classification task
+    y_true, y_pred, _ = make_prediction(binary=True)
+
+    # binary average
+    p, r, f, s = precision_recall_fgain_score_support(y_true, y_pred, average="binary")
+    assert_array_almost_equal(p, 0.82, 2)
+    assert_array_almost_equal(r, 0.53, 2)
+    assert_array_almost_equal(f, 0.68, 2)
+
+    # macro average
+    p, r, f, s = precision_recall_fgain_score_support(y_true, y_pred, average="macro")
+    assert_array_almost_equal(p, 0.73, 2)
+    assert_array_almost_equal(r, 0.70, 2)
+    assert_array_almost_equal(f, 0.72, 2)
+
+    # Test Precision Recall and F1 Score for multi classification task
+    y_true, y_pred, _ = make_prediction(binary=False)
+
+    # weighted average
+    p, r, f, s = precision_recall_fgain_score_support(
+        y_true, y_pred, average="weighted"
+    )
+    assert_array_almost_equal(p, 0.25, 2)
+    assert_array_almost_equal(r, -1.77, 2)
+    assert_array_almost_equal(f, -0.76, 2)
+
+
+def test_precision_recall_f1_gain_score_class_dist():
+    # Test Precision Recall and F1 Score for binary classification task
+    y_true, y_pred, _ = make_prediction(binary=True)
+
+    # binary average
+    p, r, f, s = precision_recall_fgain_score_support(
+        y_true, y_pred, average="binary", class_distribution=[0.4, 0.6]
+    )
+    assert_array_almost_equal(p, 0.74, 2)
+    assert_array_almost_equal(r, 0.29, 2)
+    assert_array_almost_equal(f, 0.51, 2)
+
+    # macro average
+    p, r, f, s = precision_recall_fgain_score_support(
+        y_true, y_pred, average="macro", class_distribution=[0.4, 0.6]
+    )
+    assert_array_almost_equal(p, 0.75, 2)
+    assert_array_almost_equal(r, 0.60, 2)
+    assert_array_almost_equal(f, 0.67, 2)
+
+    # Test Precision Recall and F1 Score for multi classification task
+    y_true, y_pred, _ = make_prediction(binary=False)
+
+    # weighted average
+    p, r, f, s = precision_recall_fgain_score_support(
+        y_true, y_pred, average="weighted", class_distribution=[0.4, 0.2, 0.4]
+    )
+    assert_array_almost_equal(p, 0.50, 2)
+    assert_array_almost_equal(r, -0.04, 2)
+    assert_array_almost_equal(f, 0.23, 2)
+
+
 def test_precision_recall_f1_gain_score_binary():
     # Test Precision Recall and F1 Score for binary classification task
     y_true, y_pred, _ = make_prediction(binary=True)

--- a/sklearn/metrics/tests/test_classification.py
+++ b/sklearn/metrics/tests/test_classification.py
@@ -381,6 +381,41 @@ def test_precision_recall_f_binary_single_class():
 
 
 @ignore_warnings
+def test_precision_recall_f_gain_binary_single_class():
+    # Test precision, recall and F-scores behave with a single positive or
+    # negative class. Such a case may occur with non-stratified cross-validation
+    assert 1.0 == precision_gain_score([1, 1], [1, 1])
+    assert 1.0 == recall_gain_score([1, 1], [1, 1])
+    assert 1.0 == f1_gain_score([1, 1], [1, 1])
+    assert 1.0 == fbeta_gain_score([1, 1], [1, 1], beta=0)
+    assert 1.0 == f1_gain_score([2, 2], [2, 2], pos_label=2)
+
+    # test case when no positive class present in true or predicted labels
+    assert np.isnan(precision_gain_score([2, 2], [2, 2]))
+    assert np.isnan(precision_gain_score([-1, -1], [-1, -1]))
+    assert np.isnan(recall_gain_score([-1, -1], [-1, -1]))
+    assert np.isnan(f1_gain_score([-1, -1], [-1, -1]))
+    assert np.isnan(fbeta_gain_score([-1, -1], [-1, -1], beta=float("inf")))
+    assert np.isnan(fbeta_gain_score([-1, -1], [-1, -1], beta=1e5))
+
+    # test case when true labels all positive
+    assert precision_gain_score([1, 1], [1, 0]) == 1
+    assert precision_gain_score([1, 1], [0, 1]) == 1
+    assert recall_gain_score([1, 1], [1, 0]) == -np.inf
+    assert recall_gain_score([1, 1], [0, 1]) == -np.inf
+    assert f1_gain_score([1, 1], [1, 0]) == -np.inf
+    assert f1_gain_score([1, 1], [0, 1]) == -np.inf
+
+    # test case when predicted labels all positive
+    assert precision_gain_score([1, 0], [1, 1]) == 0
+    assert precision_gain_score([0, 1], [1, 1]) == 0
+    assert recall_gain_score([1, 0], [1, 1]) == 1
+    assert recall_gain_score([0, 1], [1, 1]) == 1
+    assert_array_almost_equal(f1_gain_score([1, 0], [1, 1]), 0.5)
+    assert_array_almost_equal(f1_gain_score([0, 1], [1, 1]), 0.5)
+
+
+@ignore_warnings
 def test_precision_recall_f_extra_labels():
     # Test handling of explicit additional (not in input) labels to PRF
     y_true = [1, 3, 3, 2]


### PR DESCRIPTION
<!--
Thanks for contributing a pull request! Please ensure you have taken a look at
the contribution guidelines: https://github.com/scikit-learn/scikit-learn/blob/main/CONTRIBUTING.md
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

This PR adds Precision Gain, Recall Gain and Fscore Gain metrics to scikit-learn.

The metrics are described in this [paper](https://papers.nips.cc/paper/2015/file/33e8075e9970de0cfea955afd4644bb2-Paper.pdf) by Peter Flach and Meelis Kull at the University of Bristol, UK.

I've added test coverage for the gain metrics and utilized existing scikit-learn Precision/Recall functionality where ever possible.


The new methods, which can be imported `from sklearn.metrics` are:
```
- f1_gain_score
- fbeta_gain_score
- precision_recall_fgain_score_support
- precision_gain_score
- recall_gain_score
```

#### Any other comments?


<!--
Please be aware that we are a loose team of volunteers so patience is
necessary; assistance handling other issues is very welcome. We value
all user contributions, no matter how minor they are. If we are slow to
review, either the pull request needs some benchmarking, tinkering,
convincing, etc. or more likely the reviewers are simply busy. In either
case, we ask for your understanding during the review process.
For more information, see our FAQ on this topic:
http://scikit-learn.org/dev/faq.html#why-is-my-pull-request-not-getting-any-attention.

Thanks for contributing!
-->
